### PR TITLE
feat: perception loops + anomaly-triggered attention (sub-projects #7+#8)

### DIFF
--- a/docs/superpowers/plans/2026-05-17-perception-loops.md
+++ b/docs/superpowers/plans/2026-05-17-perception-loops.md
@@ -1,0 +1,3073 @@
+# Perception Loops Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a rate-bounded, event-driven perception system with three loops (frame / semantic / intent) and one v1 anomaly trigger (`mutation-outside-animation`). Loops wake on heartbeat or escalation; the chain produces `perception-*` events on the existing `TemporalEventStream` and a `PerceptionSessionSummary` inspectable via three new MCP tools and a Claude skill.
+
+**Architecture:** New top-level pipeline at `src/pipelines/perception/` with one orchestrator (`PerceptionSession`) and three loop classes. Pure helpers (the detector) carry decisions; loops own state + subscriptions. Escalation between loops via a session-owned `EventEmitter`. Three MCP tools (`start_perception`, `stop_perception`, `get_perception_session`) and a `perception-session` Claude skill provide the public surface. No mutation of existing pipeline outputs — perception layers on top of `FrameCapture`, `TemporalEventStream`, `AnimationCollector`, `MutationCollector`, and the #4 `Indexer`.
+
+**Tech Stack:** TypeScript (ESM with `.js` import extensions), Playwright, Vitest, pnpm, `sharp` (already a dep, for screenshot cropping), Anthropic SDK (already used via `classifyByVlm`).
+
+**Spec:** [`docs/superpowers/specs/2026-05-17-perception-loops-design.md`](../specs/2026-05-17-perception-loops-design.md).
+
+---
+
+## File Structure
+
+**New files (production):**
+
+```
+src/pipelines/perception/
+├── types.ts                                          PerceptionSessionSummary
+├── session.ts                                        PerceptionSession orchestrator
+├── frame-loop.ts                                     FrameLoop class
+├── semantic-loop.ts                                  SemanticLoop class
+├── intent-loop.ts                                    IntentLoop class
+└── anomaly/
+    └── mutation-outside-animation.ts                 pure detector
+```
+
+**New files (MCP):**
+
+```
+src/mcp/tools/perception.ts                          three factory functions sharing state
+```
+
+**New files (skill):**
+
+```
+skills/perception-session/SKILL.md
+```
+
+**New files (tests):**
+
+```
+tests/unit/pipelines/perception/
+├── types.test.ts                                     event payload + session summary type construction
+├── anomaly/
+│   └── mutation-outside-animation.test.ts            pure detector
+├── session.test.ts                                   lifecycle + summary accumulation
+├── frame-loop.test.ts                                state, subscriptions, detector wiring
+├── semantic-loop.test.ts                             cadence, escalation, indexer calls
+└── intent-loop.test.ts                               VLM call, backpressure
+
+tests/integration/perception/
+├── fixtures/
+│   └── mutation-trigger.html                         button → setTimeout text mutation
+└── perception-e2e.test.ts                            Playwright full-chain test
+
+tests/unit/mcp/
+└── perception.test.ts                                three MCP tool factories
+```
+
+**Modified files:**
+
+```
+src/pipelines/temporal/collectors/types.ts            # Add 4 EventType entries + payloads + PerceptionTier + AnomalyReason
+src/mcp/server.ts                                     # Instantiate state, register 3 tools, bump TOOL_NAMES
+tests/unit/mcp/tools.test.ts                          # TOOL_NAMES count + toContain assertions
+/Users/dirkknibbe/uipe/docs/architecture.md           # Flip #7 + #8 rows in Current implementation table
+/Users/dirkknibbe/uipe/docs/autopilot-program-roadmap.md  # Flip #7 + #8 statuses
+```
+
+**Module-boundary rationale (recap from spec):**
+- Pure detector (`anomaly/mutation-outside-animation.ts`) carries the gate logic + coalesce math; testable as plain TS.
+- `frame-loop.ts` owns state (active-animation set, recent-mutations ring buffer) and CDP/event-stream subscriptions; calls the pure detector.
+- `semantic-loop.ts` and `intent-loop.ts` follow the same "state + subscriptions + handoff to existing helpers" pattern; semantic calls `Indexer`, intent calls `classifyByVlm` — both from sub-project #4.
+- `session.ts` orchestrates lifecycle, owns an internal `EventEmitter` for inter-loop escalation, and exposes `_record*` methods loops call to update the summary + emit to the timeline.
+
+---
+
+## Common commands
+
+All commands run from the `ui-perception-engine/` directory.
+
+- Run all unit tests: `pnpm exec vitest run --reporter=verbose tests/unit/`
+- Run perception unit tests: `pnpm exec vitest run --reporter=verbose tests/unit/pipelines/perception/`
+- Run perception e2e: `pnpm exec vitest run --reporter=verbose tests/integration/perception/`
+- Run a single file: `pnpm exec vitest run --reporter=verbose <path>`
+- Typecheck: `pnpm exec tsc --noEmit`
+- Lint: `pnpm exec eslint src tests --ext .ts`
+
+After every task: typecheck passes, all previously-passing tests pass, then commit.
+
+**Note on full-suite runs:** The optical-flow integration tests are slow. If the full suite times out on a given task, scope tests to `tests/unit/` + `tests/integration/perception/` and run `pnpm exec tsc --noEmit` separately as the type-safety ground truth.
+
+---
+
+## Task 1: Event types + payload definitions
+
+**Files:**
+- Modify: `src/pipelines/temporal/collectors/types.ts`
+- Create: `src/pipelines/perception/types.ts`
+- Create: `tests/unit/pipelines/perception/types.test.ts`
+
+Types-only task. Adds four new event payloads + the session summary shape, locks the contract via type-construction assertions. Same pattern as sub-project #3 Task 1 and #4 Task 1.
+
+- [ ] **Step 1: Write `tests/unit/pipelines/perception/types.test.ts`**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import type {
+  PerceptionTier,
+  AnomalyReason,
+  PerceptionTickPayload,
+  PerceptionAnomalyPayload,
+  PerceptionEscalationPayload,
+  PerceptionIntentResultPayload,
+  TimelineEvent,
+} from '../../../../src/pipelines/temporal/collectors/types.js';
+import type { PerceptionSessionSummary } from '../../../../src/pipelines/perception/types.js';
+
+describe('PerceptionTier', () => {
+  it('accepts the three tier values', () => {
+    const tiers: PerceptionTier[] = ['frame', 'semantic', 'intent'];
+    expect(tiers).toHaveLength(3);
+  });
+});
+
+describe('AnomalyReason', () => {
+  it('accepts the v1 reason', () => {
+    const r: AnomalyReason = 'mutation-outside-animation';
+    expect(r).toBe('mutation-outside-animation');
+  });
+});
+
+describe('PerceptionTickPayload', () => {
+  it('accepts each cause value', () => {
+    const causes: Array<PerceptionTickPayload['cause']> = ['keyframe', 'heartbeat', 'escalation', 'navigation-reset'];
+    const payloads = causes.map((cause) => ({ tier: 'frame' as const, cause }));
+    expect(payloads).toHaveLength(4);
+  });
+});
+
+describe('PerceptionAnomalyPayload', () => {
+  it('accepts a full anomaly shape', () => {
+    const p: PerceptionAnomalyPayload = {
+      tier: 'frame',
+      reason: 'mutation-outside-animation',
+      detail: { mutationCount: 3, targetNodeIds: ['dom-1', 'dom-2'] },
+    };
+    expect(p.detail.mutationCount).toBe(3);
+  });
+});
+
+describe('PerceptionEscalationPayload', () => {
+  it('accepts a frame→semantic escalation', () => {
+    const p: PerceptionEscalationPayload = {
+      from: 'frame',
+      to: 'semantic',
+      reason: 'mutation-outside-animation',
+      regions: [{ nodeId: 'dom-1', bbox: { x: 0, y: 0, w: 100, h: 50 } }],
+    };
+    expect(p.regions).toHaveLength(1);
+  });
+});
+
+describe('PerceptionIntentResultPayload', () => {
+  it('accepts a complete intent result', () => {
+    const p: PerceptionIntentResultPayload = {
+      region: { nodeId: 'dom-1', bbox: { x: 0, y: 0, w: 100, h: 50 } },
+      classification: 'AnimatedCounter',
+      classificationSource: 'vlm',
+      durationMs: 873,
+    };
+    expect(p.classification).toBe('AnimatedCounter');
+  });
+});
+
+describe('TimelineEvent<perception-*>', () => {
+  it('perception-tick typechecks via PayloadFor mapping', () => {
+    const e: TimelineEvent<'perception-tick'> = {
+      id: 'evt-1', type: 'perception-tick', timestamp: 0,
+      payload: { tier: 'frame', cause: 'keyframe' },
+    };
+    expect(e.type).toBe('perception-tick');
+  });
+
+  it('perception-anomaly typechecks', () => {
+    const e: TimelineEvent<'perception-anomaly'> = {
+      id: 'evt-2', type: 'perception-anomaly', timestamp: 0,
+      payload: { tier: 'frame', reason: 'mutation-outside-animation', detail: { mutationCount: 1, targetNodeIds: ['x'] } },
+    };
+    expect(e.type).toBe('perception-anomaly');
+  });
+
+  it('perception-escalation typechecks', () => {
+    const e: TimelineEvent<'perception-escalation'> = {
+      id: 'evt-3', type: 'perception-escalation', timestamp: 0,
+      payload: { from: 'frame', to: 'semantic', reason: 'mutation-outside-animation', regions: [] },
+    };
+    expect(e.type).toBe('perception-escalation');
+  });
+
+  it('perception-intent-result typechecks', () => {
+    const e: TimelineEvent<'perception-intent-result'> = {
+      id: 'evt-4', type: 'perception-intent-result', timestamp: 0,
+      payload: {
+        region: { nodeId: 'x', bbox: { x: 0, y: 0, w: 10, h: 10 } },
+        classification: 'X',
+        classificationSource: 'vlm',
+        durationMs: 100,
+      },
+    };
+    expect(e.type).toBe('perception-intent-result');
+  });
+});
+
+describe('PerceptionSessionSummary', () => {
+  it('accepts a complete summary shape', () => {
+    const s: PerceptionSessionSummary = {
+      startedAt: 0,
+      durationMs: 5000,
+      tickCounts: { frame: 12, semantic: 3, intent: 1 },
+      averageCadenceMs: { frame: 100, semantic: 1500, intent: null },
+      targetCadenceMs: { frame: 16, semantic: 200, intent: 1000 },
+      anomalyCount: 2,
+      anomaliesByReason: { 'mutation-outside-animation': 2 },
+      escalationCount: 3,
+      intentResultCount: 1,
+      vlmCalls: { count: 1, estimatedDollars: 0.02 },
+    };
+    expect(s.anomalyCount).toBe(2);
+  });
+
+  it('accepts a summary with null averageCadenceMs for an unused tier', () => {
+    const s: PerceptionSessionSummary = {
+      startedAt: 0, durationMs: 100,
+      tickCounts: { frame: 0, semantic: 0, intent: 0 },
+      averageCadenceMs: { frame: null, semantic: null, intent: null },
+      targetCadenceMs: { frame: 16, semantic: 200, intent: 1000 },
+      anomalyCount: 0,
+      anomaliesByReason: { 'mutation-outside-animation': 0 },
+      escalationCount: 0,
+      intentResultCount: 0,
+      vlmCalls: { count: 0 },
+    };
+    expect(s.tickCounts.frame).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run typecheck — should FAIL because types don't exist yet**
+
+```bash
+pnpm exec tsc --noEmit
+```
+Expected: errors about `PerceptionTickPayload`, `AnomalyReason`, etc. not being exported.
+
+- [ ] **Step 3: Modify `src/pipelines/temporal/collectors/types.ts` — extend the `EventType` union**
+
+Find:
+```typescript
+export type EventType =
+  | 'input'
+  | 'mutation'
+  | 'network-request'
+  | 'network-response'
+  | 'animation-start'
+  | 'animation-end'
+  | 'animation-prediction'
+  | 'phash-change'
+  | 'optical-flow-raw'
+  | 'optical-flow-region'
+  | 'optical-flow-motion';
+```
+
+Replace with:
+```typescript
+export type EventType =
+  | 'input'
+  | 'mutation'
+  | 'network-request'
+  | 'network-response'
+  | 'animation-start'
+  | 'animation-end'
+  | 'animation-prediction'
+  | 'phash-change'
+  | 'optical-flow-raw'
+  | 'optical-flow-region'
+  | 'optical-flow-motion'
+  | 'perception-tick'
+  | 'perception-anomaly'
+  | 'perception-escalation'
+  | 'perception-intent-result';
+```
+
+- [ ] **Step 4: In the same file, add the new payload types**
+
+Add these exports after the existing `OpticalFlow*Payload` definitions (search for `OpticalFlowMotionPayload` and add after it):
+
+```typescript
+export type PerceptionTier = 'frame' | 'semantic' | 'intent';
+
+export type AnomalyReason = 'mutation-outside-animation';
+
+export interface PerceptionTickPayload {
+  tier: PerceptionTier;
+  cause: 'keyframe' | 'heartbeat' | 'escalation' | 'navigation-reset';
+}
+
+export interface PerceptionAnomalyPayload {
+  tier: PerceptionTier;
+  reason: AnomalyReason;
+  detail: {
+    mutationCount: number;
+    targetNodeIds: string[];
+  };
+}
+
+export interface PerceptionEscalationPayload {
+  from: PerceptionTier;
+  to: PerceptionTier;
+  reason: AnomalyReason;
+  regions: Array<{
+    nodeId: string;
+    bbox: { x: number; y: number; w: number; h: number };
+  }>;
+}
+
+export interface PerceptionIntentResultPayload {
+  region: { nodeId: string; bbox: { x: number; y: number; w: number; h: number } };
+  classification: string;
+  classificationSource: 'vlm';
+  durationMs: number;
+}
+```
+
+- [ ] **Step 5: In the same file, extend the `PayloadFor` mapped type**
+
+Find:
+```typescript
+export type PayloadFor<T extends EventType> =
+  T extends 'input'             ? InputPayload :
+  T extends 'mutation'          ? MutationPayload :
+  T extends 'network-request'   ? NetworkRequestPayload :
+  T extends 'network-response'  ? NetworkResponsePayload :
+  T extends 'animation-start'   ? AnimationStartPayload :
+  T extends 'animation-end'     ? AnimationEndPayload :
+  T extends 'animation-prediction' ? AnimationPredictionPayload :
+  T extends 'phash-change'      ? PHashChangePayload :
+  T extends 'optical-flow-raw'    ? OpticalFlowRawPayload :
+  T extends 'optical-flow-region' ? OpticalFlowRegionPayload :
+  T extends 'optical-flow-motion' ? OpticalFlowMotionPayload :
+  never;
+```
+
+Replace with:
+```typescript
+export type PayloadFor<T extends EventType> =
+  T extends 'input'             ? InputPayload :
+  T extends 'mutation'          ? MutationPayload :
+  T extends 'network-request'   ? NetworkRequestPayload :
+  T extends 'network-response'  ? NetworkResponsePayload :
+  T extends 'animation-start'   ? AnimationStartPayload :
+  T extends 'animation-end'     ? AnimationEndPayload :
+  T extends 'animation-prediction' ? AnimationPredictionPayload :
+  T extends 'phash-change'      ? PHashChangePayload :
+  T extends 'optical-flow-raw'    ? OpticalFlowRawPayload :
+  T extends 'optical-flow-region' ? OpticalFlowRegionPayload :
+  T extends 'optical-flow-motion' ? OpticalFlowMotionPayload :
+  T extends 'perception-tick'           ? PerceptionTickPayload :
+  T extends 'perception-anomaly'        ? PerceptionAnomalyPayload :
+  T extends 'perception-escalation'     ? PerceptionEscalationPayload :
+  T extends 'perception-intent-result'  ? PerceptionIntentResultPayload :
+  never;
+```
+
+- [ ] **Step 6: Create `src/pipelines/perception/types.ts`**
+
+```typescript
+import type { PerceptionTier, AnomalyReason } from '../temporal/collectors/types.js';
+
+export interface PerceptionSessionSummary {
+  startedAt: number;                  // stream-relative ms at session start
+  durationMs: number;                 // wall-clock elapsed since startedAt
+  tickCounts: Record<PerceptionTier, number>;
+  averageCadenceMs: Record<PerceptionTier, number | null>;  // null if loop never ticked
+  targetCadenceMs: Record<PerceptionTier, number>;          // declared target
+  anomalyCount: number;
+  anomaliesByReason: Record<AnomalyReason, number>;
+  escalationCount: number;
+  intentResultCount: number;
+  vlmCalls: { count: number; estimatedDollars?: number };
+}
+```
+
+- [ ] **Step 7: Run typecheck and the new tests**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec vitest run --reporter=verbose tests/unit/pipelines/perception/types.test.ts
+```
+Expected: typecheck passes, 12 test cases pass.
+
+- [ ] **Step 8: Run the full unit suite to confirm nothing else broke**
+
+```bash
+pnpm exec vitest run --reporter=dot tests/unit/
+```
+Expected: previously-passing tests still pass plus 12 new ones.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/pipelines/temporal/collectors/types.ts src/pipelines/perception/types.ts tests/unit/pipelines/perception/types.test.ts
+git commit -m "feat(perception): event types + session summary shape"
+```
+
+---
+
+## Task 2: Pure detector — `mutation-outside-animation`
+
+**Files:**
+- Create: `src/pipelines/perception/anomaly/mutation-outside-animation.ts`
+- Create: `tests/unit/pipelines/perception/anomaly/mutation-outside-animation.test.ts`
+
+The v1 anomaly trigger. Pure function — no I/O, no async, no side effects. Takes `recentMutations` + `activeAnimations` + timestamps + config; returns either `null` or `{ mutationCount, targetNodeIds }`. Decision logic per spec §"v1 anomaly trigger — mutation-outside-animation":
+
+1. Warmup gate: `nowMs - sessionStartMs < warmupMs` → null
+2. Active-animation gate: `activeAnimations.size > 0` → null
+3. Coalesce: group mutations into bursts (gaps ≤ `coalesceWindowMs` join); take the latest burst
+4. Empty short-circuit
+5. Emit result
+
+- [ ] **Step 1: Write `tests/unit/pipelines/perception/anomaly/mutation-outside-animation.test.ts`**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { detectMutationOutsideAnimation } from '../../../../../src/pipelines/perception/anomaly/mutation-outside-animation.js';
+import type { TimelineEvent } from '../../../../../src/pipelines/temporal/collectors/types.js';
+
+function mkMutation(timestamp: number, targetNodeId: string): TimelineEvent<'mutation'> {
+  return {
+    id: `evt-${timestamp}-${targetNodeId}`,
+    type: 'mutation',
+    timestamp,
+    payload: {
+      mutationType: 'childList',
+      targetNodeId,
+      addedNodes: [],
+      removedNodes: [],
+      attributeName: undefined,
+      oldValue: undefined,
+      newValue: undefined,
+    },
+  };
+}
+
+const DEFAULTS = { lookbackMs: 200, coalesceWindowMs: 100, warmupMs: 500 };
+
+describe('detectMutationOutsideAnimation', () => {
+  it('returns null during warmup window', () => {
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [mkMutation(100, 'a')],
+      activeAnimations: new Set(),
+      nowMs: 400,            // 400 - 0 = 400 < 500ms warmup
+      sessionStartMs: 0,
+    }, DEFAULTS);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when any animation is active', () => {
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [mkMutation(900, 'a')],
+      activeAnimations: new Set(['anim-1']),
+      nowMs: 1000,
+      sessionStartMs: 0,
+    }, DEFAULTS);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no mutations', () => {
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [],
+      activeAnimations: new Set(),
+      nowMs: 1000,
+      sessionStartMs: 0,
+    }, DEFAULTS);
+    expect(result).toBeNull();
+  });
+
+  it('returns result when past warmup + no animation + has mutations', () => {
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [mkMutation(950, 'a'), mkMutation(960, 'b')],
+      activeAnimations: new Set(),
+      nowMs: 1000,
+      sessionStartMs: 0,
+    }, DEFAULTS);
+    expect(result).toEqual({
+      mutationCount: 2,
+      targetNodeIds: ['a', 'b'],
+    });
+  });
+
+  it('coalesces mutations within the coalesce window into one burst', () => {
+    // Three mutations at 900, 950, 990 — gaps 50ms and 40ms, both ≤ 100ms coalesce
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [
+        mkMutation(900, 'a'),
+        mkMutation(950, 'b'),
+        mkMutation(990, 'c'),
+      ],
+      activeAnimations: new Set(),
+      nowMs: 1000,
+      sessionStartMs: 0,
+    }, DEFAULTS);
+    expect(result).toEqual({
+      mutationCount: 3,
+      targetNodeIds: ['a', 'b', 'c'],
+    });
+  });
+
+  it('takes only the latest burst when multiple non-overlapping bursts exist', () => {
+    // Burst A: 600-650 (older). Burst B: 950-990 (latest). Gap = 300ms > coalesce.
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [
+        mkMutation(600, 'old1'),
+        mkMutation(650, 'old2'),
+        mkMutation(950, 'new1'),
+        mkMutation(990, 'new2'),
+      ],
+      activeAnimations: new Set(),
+      nowMs: 1000,
+      sessionStartMs: 0,
+    }, DEFAULTS);
+    expect(result).toEqual({
+      mutationCount: 2,
+      targetNodeIds: ['new1', 'new2'],
+    });
+  });
+
+  it('deduplicates target node IDs', () => {
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [
+        mkMutation(900, 'a'),
+        mkMutation(920, 'a'),     // same node mutated twice
+        mkMutation(950, 'b'),
+      ],
+      activeAnimations: new Set(),
+      nowMs: 1000,
+      sessionStartMs: 0,
+    }, DEFAULTS);
+    expect(result?.targetNodeIds).toEqual(['a', 'b']);
+    // mutationCount counts the events; targetNodeIds is deduped
+    expect(result?.mutationCount).toBe(3);
+  });
+
+  it('treats a single mutation as a one-event burst', () => {
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [mkMutation(950, 'a')],
+      activeAnimations: new Set(),
+      nowMs: 1000,
+      sessionStartMs: 0,
+    }, DEFAULTS);
+    expect(result).toEqual({ mutationCount: 1, targetNodeIds: ['a'] });
+  });
+
+  it('uses provided config over defaults', () => {
+    // Override warmup to 0 → no suppression
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [mkMutation(100, 'a')],
+      activeAnimations: new Set(),
+      nowMs: 200,
+      sessionStartMs: 0,
+    }, { lookbackMs: 200, coalesceWindowMs: 100, warmupMs: 0 });
+    expect(result).toEqual({ mutationCount: 1, targetNodeIds: ['a'] });
+  });
+});
+```
+
+- [ ] **Step 2: Run — should FAIL (module not found)**
+
+```bash
+pnpm exec vitest run --reporter=verbose tests/unit/pipelines/perception/anomaly/mutation-outside-animation.test.ts
+```
+Expected: module-not-found errors.
+
+- [ ] **Step 3: Create `src/pipelines/perception/anomaly/mutation-outside-animation.ts`**
+
+```typescript
+import type { TimelineEvent } from '../../temporal/collectors/types.js';
+
+export interface DetectInput {
+  recentMutations: TimelineEvent<'mutation'>[];
+  activeAnimations: Set<string>;
+  nowMs: number;
+  sessionStartMs: number;
+}
+
+export interface DetectConfig {
+  lookbackMs: number;
+  coalesceWindowMs: number;
+  warmupMs: number;
+}
+
+export type DetectResult =
+  | null
+  | { mutationCount: number; targetNodeIds: string[] };
+
+export const DEFAULT_CONFIG: DetectConfig = {
+  lookbackMs: 200,
+  coalesceWindowMs: 100,
+  warmupMs: 500,
+};
+
+/**
+ * Pure detector for the v1 anomaly trigger. Returns a result when:
+ *   - past the warmup window
+ *   - no animation is currently active
+ *   - at least one mutation falls within the latest coalesced burst
+ *
+ * `recentMutations` is assumed to already be trimmed to `lookbackMs` by the
+ * caller (FrameLoop maintains a ring buffer).
+ */
+export function detectMutationOutsideAnimation(
+  input: DetectInput,
+  config: DetectConfig = DEFAULT_CONFIG,
+): DetectResult {
+  // 1. Warmup gate
+  if (input.nowMs - input.sessionStartMs < config.warmupMs) return null;
+
+  // 2. Active animation gate
+  if (input.activeAnimations.size > 0) return null;
+
+  // 3. Coalesce — group mutations into bursts, take the latest
+  if (input.recentMutations.length === 0) return null;
+
+  // Sort by timestamp ascending to make grouping deterministic
+  const sorted = [...input.recentMutations].sort((a, b) => a.timestamp - b.timestamp);
+
+  // Find the latest burst by walking backwards: include events while the gap
+  // to the previous event is ≤ coalesceWindowMs.
+  const latest = sorted[sorted.length - 1];
+  const burst: TimelineEvent<'mutation'>[] = [latest];
+  for (let i = sorted.length - 2; i >= 0; i--) {
+    const gap = burst[burst.length - 1].timestamp - sorted[i].timestamp;
+    if (gap > config.coalesceWindowMs) break;
+    burst.push(sorted[i]);
+  }
+
+  // 4. Empty short-circuit (defensive — shouldn't hit since we returned null above on empty)
+  if (burst.length === 0) return null;
+
+  // 5. Emit. Dedupe target IDs.
+  const uniqueIds = Array.from(new Set(burst.map((e) => e.payload.targetNodeId)));
+  return {
+    mutationCount: burst.length,
+    targetNodeIds: uniqueIds,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests — all should pass**
+
+```bash
+pnpm exec vitest run --reporter=verbose tests/unit/pipelines/perception/anomaly/mutation-outside-animation.test.ts
+```
+Expected: 9 passing.
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+pnpm exec tsc --noEmit
+```
+Expected: passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pipelines/perception/anomaly/mutation-outside-animation.ts tests/unit/pipelines/perception/anomaly/mutation-outside-animation.test.ts
+git commit -m "feat(perception): pure detector — mutation-outside-animation"
+```
+
+---
+
+## Task 3: `PerceptionSession` skeleton + lifecycle
+
+**Files:**
+- Create: `src/pipelines/perception/session.ts`
+- Create: `tests/unit/pipelines/perception/session.test.ts`
+
+Builds the orchestrator class with lifecycle (`start`/`stop`/`getSummary`) and the internal `_record*` methods loops call to update summary state + emit timeline events. No loops are wired in this task — they're added in tasks 4-7. This task establishes the contract.
+
+The class also owns a private `EventEmitter` for inter-loop escalation. We expose `internalEmitter` (intentionally — loops in sibling files need it). It is not part of the public MCP surface.
+
+**Note on TemporalEventStream API:** `TemporalEventStream.recordEvent(type, payload, timestamp?)` is the way collectors push events onto the timeline. The session uses the same method. If your local copy of `event-stream.ts` exposes a different name (e.g. `emit`, `push`), use the same name the existing collectors use — open `src/pipelines/temporal/collectors/animation.ts` to see the canonical call pattern.
+
+- [ ] **Step 1: Verify TemporalEventStream's emit method name**
+
+```bash
+grep -n "this.stream\." src/pipelines/temporal/collectors/animation.ts | head -5
+```
+
+Note the method name used to push events (e.g. `recordEvent`, `emit`, `addEvent`). Use that exact name in all subsequent code.
+
+- [ ] **Step 2: Write `tests/unit/pipelines/perception/session.test.ts`**
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PerceptionSession } from '../../../../src/pipelines/perception/session.js';
+import type { TemporalEventStream } from '../../../../src/pipelines/temporal/event-stream.js';
+
+function mkStream() {
+  return {
+    recordEvent: vi.fn(),
+  } as unknown as TemporalEventStream;
+}
+
+describe('PerceptionSession lifecycle', () => {
+  let stream: TemporalEventStream;
+  let session: PerceptionSession;
+
+  beforeEach(() => {
+    stream = mkStream();
+    session = new PerceptionSession({ eventStream: stream });
+  });
+
+  it('summary starts with zero counts and target cadences', () => {
+    const s = session.getSummary();
+    expect(s.tickCounts).toEqual({ frame: 0, semantic: 0, intent: 0 });
+    expect(s.anomalyCount).toBe(0);
+    expect(s.targetCadenceMs.semantic).toBe(200);
+    expect(s.targetCadenceMs.intent).toBe(1000);
+  });
+
+  it('start() sets startedAt', () => {
+    session.start(100);
+    const s = session.getSummary();
+    expect(s.startedAt).toBe(100);
+  });
+
+  it('start() called twice throws', () => {
+    session.start(100);
+    expect(() => session.start(200)).toThrow();
+  });
+
+  it('stop() sets durationMs based on time elapsed', () => {
+    session.start(100);
+    session.stop(450);
+    const s = session.getSummary();
+    expect(s.durationMs).toBe(350);
+  });
+
+  it('stop() without start throws', () => {
+    expect(() => session.stop(100)).toThrow();
+  });
+
+  it('_recordTick increments tier count and emits perception-tick', () => {
+    session.start(100);
+    session.recordTick('frame', 'keyframe', 150);
+    const s = session.getSummary();
+    expect(s.tickCounts.frame).toBe(1);
+    expect(stream.recordEvent).toHaveBeenCalledWith('perception-tick', { tier: 'frame', cause: 'keyframe' }, 150);
+  });
+
+  it('_recordAnomaly increments anomalyCount and reason bucket', () => {
+    session.start(100);
+    session.recordAnomaly('frame', 'mutation-outside-animation', { mutationCount: 2, targetNodeIds: ['x', 'y'] }, 200);
+    const s = session.getSummary();
+    expect(s.anomalyCount).toBe(1);
+    expect(s.anomaliesByReason['mutation-outside-animation']).toBe(1);
+    expect(stream.recordEvent).toHaveBeenCalledWith(
+      'perception-anomaly',
+      { tier: 'frame', reason: 'mutation-outside-animation', detail: { mutationCount: 2, targetNodeIds: ['x', 'y'] } },
+      200,
+    );
+  });
+
+  it('_recordEscalation increments escalationCount', () => {
+    session.start(100);
+    session.recordEscalation('frame', 'semantic', 'mutation-outside-animation', [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }], 250);
+    expect(session.getSummary().escalationCount).toBe(1);
+    expect(stream.recordEvent).toHaveBeenCalledWith(
+      'perception-escalation',
+      expect.objectContaining({ from: 'frame', to: 'semantic' }),
+      250,
+    );
+  });
+
+  it('_recordIntentResult increments intentResultCount + vlmCalls.count', () => {
+    session.start(100);
+    session.recordIntentResult(
+      { nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } },
+      'AnimatedCounter',
+      300,
+      400,
+    );
+    const s = session.getSummary();
+    expect(s.intentResultCount).toBe(1);
+    expect(s.vlmCalls.count).toBe(1);
+    expect(stream.recordEvent).toHaveBeenCalledWith(
+      'perception-intent-result',
+      expect.objectContaining({ classification: 'AnimatedCounter', classificationSource: 'vlm', durationMs: 300 }),
+      400,
+    );
+  });
+
+  it('averageCadenceMs computes mean inter-tick interval per tier', () => {
+    session.start(0);
+    session.recordTick('frame', 'keyframe', 100);
+    session.recordTick('frame', 'keyframe', 300);    // gap 200
+    session.recordTick('frame', 'keyframe', 500);    // gap 200
+    const s = session.getSummary();
+    expect(s.averageCadenceMs.frame).toBe(200);
+    expect(s.averageCadenceMs.semantic).toBeNull();
+    expect(s.averageCadenceMs.intent).toBeNull();
+  });
+
+  it('internalEmitter is a usable EventEmitter', () => {
+    const handler = vi.fn();
+    session.internalEmitter.on('escalate', handler);
+    session.internalEmitter.emit('escalate', { from: 'frame', regions: [] });
+    expect(handler).toHaveBeenCalledWith({ from: 'frame', regions: [] });
+  });
+});
+```
+
+- [ ] **Step 3: Run — should FAIL (module not found)**
+
+```bash
+pnpm exec vitest run --reporter=verbose tests/unit/pipelines/perception/session.test.ts
+```
+
+- [ ] **Step 4: Create `src/pipelines/perception/session.ts`**
+
+```typescript
+import { EventEmitter } from 'node:events';
+import type {
+  AnomalyReason,
+  PerceptionTier,
+  PerceptionEscalationPayload,
+} from '../temporal/collectors/types.js';
+import type { TemporalEventStream } from '../temporal/event-stream.js';
+import type { PerceptionSessionSummary } from './types.js';
+
+const TARGET_CADENCE_MS: Record<PerceptionTier, number> = {
+  frame: 16,        // not actually used — frame is keyframe-bound; surfaced for inspection
+  semantic: 200,
+  intent: 1000,
+};
+
+const ALL_ANOMALY_REASONS: AnomalyReason[] = ['mutation-outside-animation'];
+
+interface PerceptionSessionOptions {
+  eventStream: TemporalEventStream;
+}
+
+interface TickRecord {
+  count: number;
+  lastTimestamp: number | null;
+  intervalSum: number;     // sum of intervals between consecutive ticks
+  intervalCount: number;   // number of intervals (count - 1)
+}
+
+export class PerceptionSession {
+  readonly internalEmitter = new EventEmitter();
+
+  private state: 'idle' | 'running' | 'stopped' = 'idle';
+  private startedAt = 0;
+  private stoppedAt = 0;
+  private readonly stream: TemporalEventStream;
+
+  private readonly ticks: Record<PerceptionTier, TickRecord> = {
+    frame:    { count: 0, lastTimestamp: null, intervalSum: 0, intervalCount: 0 },
+    semantic: { count: 0, lastTimestamp: null, intervalSum: 0, intervalCount: 0 },
+    intent:   { count: 0, lastTimestamp: null, intervalSum: 0, intervalCount: 0 },
+  };
+
+  private anomalyCount = 0;
+  private anomaliesByReason: Record<AnomalyReason, number> = {
+    'mutation-outside-animation': 0,
+  };
+  private escalationCount = 0;
+  private intentResultCount = 0;
+  private vlmCallCount = 0;
+
+  constructor(opts: PerceptionSessionOptions) {
+    this.stream = opts.eventStream;
+  }
+
+  start(nowMs: number): void {
+    if (this.state === 'running') {
+      throw new Error('PerceptionSession.start: already running');
+    }
+    this.state = 'running';
+    this.startedAt = nowMs;
+    this.stoppedAt = 0;
+  }
+
+  stop(nowMs: number): void {
+    if (this.state !== 'running') {
+      throw new Error('PerceptionSession.stop: not running');
+    }
+    this.state = 'stopped';
+    this.stoppedAt = nowMs;
+    this.internalEmitter.removeAllListeners();
+  }
+
+  isRunning(): boolean {
+    return this.state === 'running';
+  }
+
+  getStartedAt(): number {
+    return this.startedAt;
+  }
+
+  /** Reset sessionStartMs after a navigation event so the warmup gate re-applies. */
+  resetStartedAt(nowMs: number): void {
+    this.startedAt = nowMs;
+  }
+
+  recordTick(tier: PerceptionTier, cause: 'keyframe' | 'heartbeat' | 'escalation' | 'navigation-reset', timestamp: number): void {
+    const t = this.ticks[tier];
+    t.count += 1;
+    if (t.lastTimestamp !== null) {
+      t.intervalSum += timestamp - t.lastTimestamp;
+      t.intervalCount += 1;
+    }
+    t.lastTimestamp = timestamp;
+    this.stream.recordEvent('perception-tick', { tier, cause }, timestamp);
+  }
+
+  recordAnomaly(tier: PerceptionTier, reason: AnomalyReason, detail: { mutationCount: number; targetNodeIds: string[] }, timestamp: number): void {
+    this.anomalyCount += 1;
+    this.anomaliesByReason[reason] += 1;
+    this.stream.recordEvent('perception-anomaly', { tier, reason, detail }, timestamp);
+  }
+
+  recordEscalation(from: PerceptionTier, to: PerceptionTier, reason: AnomalyReason, regions: PerceptionEscalationPayload['regions'], timestamp: number): void {
+    this.escalationCount += 1;
+    this.stream.recordEvent('perception-escalation', { from, to, reason, regions }, timestamp);
+  }
+
+  recordIntentResult(
+    region: { nodeId: string; bbox: { x: number; y: number; w: number; h: number } },
+    classification: string,
+    durationMs: number,
+    timestamp: number,
+  ): void {
+    this.intentResultCount += 1;
+    this.vlmCallCount += 1;
+    this.stream.recordEvent(
+      'perception-intent-result',
+      { region, classification, classificationSource: 'vlm', durationMs },
+      timestamp,
+    );
+  }
+
+  getSummary(): PerceptionSessionSummary {
+    const now = this.state === 'running' ? Date.now() : this.stoppedAt;
+    const durationMs = this.state === 'idle' ? 0 : now - this.startedAt;
+
+    const averageCadenceMs: Record<PerceptionTier, number | null> = {
+      frame: this.ticks.frame.intervalCount > 0 ? this.ticks.frame.intervalSum / this.ticks.frame.intervalCount : null,
+      semantic: this.ticks.semantic.intervalCount > 0 ? this.ticks.semantic.intervalSum / this.ticks.semantic.intervalCount : null,
+      intent: this.ticks.intent.intervalCount > 0 ? this.ticks.intent.intervalSum / this.ticks.intent.intervalCount : null,
+    };
+
+    // Initialize anomaliesByReason buckets with zeros even if never fired
+    const anomaliesByReason = {} as Record<AnomalyReason, number>;
+    for (const r of ALL_ANOMALY_REASONS) {
+      anomaliesByReason[r] = this.anomaliesByReason[r] ?? 0;
+    }
+
+    return {
+      startedAt: this.startedAt,
+      durationMs,
+      tickCounts: {
+        frame: this.ticks.frame.count,
+        semantic: this.ticks.semantic.count,
+        intent: this.ticks.intent.count,
+      },
+      averageCadenceMs,
+      targetCadenceMs: TARGET_CADENCE_MS,
+      anomalyCount: this.anomalyCount,
+      anomaliesByReason,
+      escalationCount: this.escalationCount,
+      intentResultCount: this.intentResultCount,
+      vlmCalls: { count: this.vlmCallCount },
+    };
+  }
+}
+```
+
+- [ ] **Step 5: If `TemporalEventStream.recordEvent` doesn't match the actual method name in your codebase, update accordingly**
+
+Open `src/pipelines/temporal/event-stream.ts` and check the public method name for adding events. If it's different (e.g. `record`, `addEvent`, `push`), update both `session.ts` and the test's mock to match.
+
+- [ ] **Step 6: Run tests — all should pass**
+
+```bash
+pnpm exec vitest run --reporter=verbose tests/unit/pipelines/perception/session.test.ts
+```
+Expected: 11 passing.
+
+- [ ] **Step 7: Typecheck**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pipelines/perception/session.ts tests/unit/pipelines/perception/session.test.ts
+git commit -m "feat(perception): PerceptionSession orchestrator skeleton"
+```
+
+---
+
+## Task 4: `FrameLoop`
+
+**Files:**
+- Create: `src/pipelines/perception/frame-loop.ts`
+- Create: `tests/unit/pipelines/perception/frame-loop.test.ts`
+
+Subscribes to `FrameCapture` keyframes and `TemporalEventStream` for animation + mutation events. Maintains `activeAnimations: Set<string>` and `recentMutations: TimelineEvent<'mutation'>[]` ring buffer. On each keyframe: trim buffer, emit tick, run detector, emit anomaly + escalation if triggered.
+
+**Note on FrameCapture's emit shape:** open `src/pipelines/visual/frame-capture.ts` and verify the `keyframe` event payload shape (likely `{ frame: Buffer, timestamp: number }`). The loop subscribes via `frameCapture.on('keyframe', handler)`.
+
+**Note on TemporalEventStream subscription:** open `src/pipelines/temporal/event-stream.ts` to find how external consumers subscribe to events. If it exposes `on('event', handler)` or similar, use that. If not — confirm and adapt the code. The pattern in #3's collectors is the canonical reference.
+
+- [ ] **Step 1: Verify FrameCapture + EventStream APIs**
+
+```bash
+grep -n "emit\|EventEmitter\|on\(" src/pipelines/visual/frame-capture.ts | head -10
+grep -n "on\(\|subscribe\|removeListener" src/pipelines/temporal/event-stream.ts | head -10
+```
+
+Note the exact subscription method (likely `.on('keyframe', ...)` and `.on('event', ...)`). Update the code below accordingly if names differ.
+
+- [ ] **Step 2: Write `tests/unit/pipelines/perception/frame-loop.test.ts`**
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { FrameLoop } from '../../../../src/pipelines/perception/frame-loop.js';
+import { PerceptionSession } from '../../../../src/pipelines/perception/session.js';
+import type { TemporalEventStream } from '../../../../src/pipelines/temporal/event-stream.js';
+import type { TimelineEvent } from '../../../../src/pipelines/temporal/collectors/types.js';
+
+class FakeFrameCapture extends EventEmitter {
+  emitKeyframe(timestamp: number, frame = Buffer.from([0x89, 0x50])) {
+    this.emit('keyframe', { frame, timestamp });
+  }
+}
+
+class FakeEventStream extends EventEmitter {
+  recordEvent = vi.fn();
+  pushEvent(type: TimelineEvent['type'], payload: any, timestamp = Date.now()) {
+    this.emit('event', { id: `e-${timestamp}`, type, timestamp, payload });
+  }
+}
+
+function setup(config?: { lookbackMs?: number; coalesceWindowMs?: number; warmupMs?: number }) {
+  const stream = new FakeEventStream();
+  const session = new PerceptionSession({ eventStream: stream as unknown as TemporalEventStream });
+  const frameCapture = new FakeFrameCapture();
+  const loop = new FrameLoop({
+    session,
+    frameCapture: frameCapture as any,
+    eventStream: stream as unknown as TemporalEventStream,
+    config,
+  });
+  return { stream, session, frameCapture, loop };
+}
+
+describe('FrameLoop', () => {
+  it('emits perception-tick { tier: frame, cause: keyframe } on each keyframe', () => {
+    const { session, frameCapture, loop, stream } = setup();
+    session.start(0);
+    loop.start();
+    frameCapture.emitKeyframe(600);
+    expect(stream.recordEvent).toHaveBeenCalledWith(
+      'perception-tick',
+      { tier: 'frame', cause: 'keyframe' },
+      600,
+    );
+  });
+
+  it('tracks active animations via animation-start / animation-end events', () => {
+    const { session, frameCapture, loop, stream } = setup({ warmupMs: 0 });
+    session.start(0);
+    loop.start();
+    stream.pushEvent('animation-start', { animationId: 'a-1', startTimestamp: 50 }, 50);
+    // Mutation while animation active → no anomaly
+    stream.pushEvent('mutation', { mutationType: 'childList', targetNodeId: 'x', addedNodes: [], removedNodes: [] }, 100);
+    frameCapture.emitKeyframe(120);
+    expect(stream.recordEvent).not.toHaveBeenCalledWith('perception-anomaly', expect.anything(), expect.anything());
+
+    // End animation, mutation now triggers anomaly
+    stream.pushEvent('animation-end', { animationId: 'a-1', reason: 'completed' }, 200);
+    stream.pushEvent('mutation', { mutationType: 'childList', targetNodeId: 'y', addedNodes: [], removedNodes: [] }, 220);
+    frameCapture.emitKeyframe(240);
+    expect(stream.recordEvent).toHaveBeenCalledWith(
+      'perception-anomaly',
+      expect.objectContaining({ tier: 'frame', reason: 'mutation-outside-animation' }),
+      240,
+    );
+  });
+
+  it('emits perception-anomaly and perception-escalation when detector fires', () => {
+    const { session, frameCapture, loop, stream } = setup({ warmupMs: 0 });
+    session.start(0);
+    loop.start();
+    stream.pushEvent('mutation', { mutationType: 'childList', targetNodeId: 'a', addedNodes: [], removedNodes: [] }, 100);
+    frameCapture.emitKeyframe(120);
+
+    expect(stream.recordEvent).toHaveBeenCalledWith(
+      'perception-anomaly',
+      expect.objectContaining({ reason: 'mutation-outside-animation' }),
+      120,
+    );
+    expect(stream.recordEvent).toHaveBeenCalledWith(
+      'perception-escalation',
+      expect.objectContaining({ from: 'frame', to: 'semantic' }),
+      120,
+    );
+  });
+
+  it('emits an escalate event on internalEmitter for the semantic loop', () => {
+    const { session, frameCapture, loop, stream } = setup({ warmupMs: 0 });
+    const handler = vi.fn();
+    session.internalEmitter.on('escalate', handler);
+    session.start(0);
+    loop.start();
+    stream.pushEvent('mutation', { mutationType: 'childList', targetNodeId: 'a', addedNodes: [], removedNodes: [] }, 100);
+    frameCapture.emitKeyframe(120);
+
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ from: 'frame' }));
+  });
+
+  it('trims recentMutations older than lookbackMs', () => {
+    const { session, frameCapture, loop, stream } = setup({ lookbackMs: 100, warmupMs: 0 });
+    session.start(0);
+    loop.start();
+    // Old mutation falls outside the lookback window
+    stream.pushEvent('mutation', { mutationType: 'childList', targetNodeId: 'old', addedNodes: [], removedNodes: [] }, 0);
+    frameCapture.emitKeyframe(500);  // 500 - 0 = 500 > lookbackMs 100
+    expect(stream.recordEvent).not.toHaveBeenCalledWith('perception-anomaly', expect.anything(), expect.anything());
+  });
+
+  it('debounces back-to-back keyframes within coalesce window', () => {
+    const { session, frameCapture, loop, stream } = setup({ warmupMs: 0, coalesceWindowMs: 100 });
+    session.start(0);
+    loop.start();
+    stream.pushEvent('mutation', { mutationType: 'childList', targetNodeId: 'a', addedNodes: [], removedNodes: [] }, 100);
+    frameCapture.emitKeyframe(110);
+    frameCapture.emitKeyframe(150);   // within 100ms of last anomaly emit
+    const anomalyCalls = (stream.recordEvent as any).mock.calls.filter((c: any[]) => c[0] === 'perception-anomaly');
+    expect(anomalyCalls).toHaveLength(1);
+  });
+
+  it('stop() unsubscribes from frameCapture and eventStream', () => {
+    const { session, frameCapture, loop, stream } = setup({ warmupMs: 0 });
+    session.start(0);
+    loop.start();
+    loop.stop();
+    stream.pushEvent('mutation', { mutationType: 'childList', targetNodeId: 'a', addedNodes: [], removedNodes: [] }, 100);
+    frameCapture.emitKeyframe(120);
+    // No ticks after stop()
+    const tickCalls = (stream.recordEvent as any).mock.calls.filter((c: any[]) => c[0] === 'perception-tick');
+    expect(tickCalls).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 3: Run — should FAIL (module not found)**
+
+```bash
+pnpm exec vitest run --reporter=verbose tests/unit/pipelines/perception/frame-loop.test.ts
+```
+
+- [ ] **Step 4: Create `src/pipelines/perception/frame-loop.ts`**
+
+```typescript
+import type { FrameCapture } from '../visual/frame-capture.js';
+import type { TemporalEventStream } from '../temporal/event-stream.js';
+import type { TimelineEvent, EventType } from '../temporal/collectors/types.js';
+import type { PerceptionSession } from './session.js';
+import {
+  detectMutationOutsideAnimation,
+  DEFAULT_CONFIG,
+  type DetectConfig,
+} from './anomaly/mutation-outside-animation.js';
+
+export interface FrameLoopOptions {
+  session: PerceptionSession;
+  frameCapture: FrameCapture;
+  eventStream: TemporalEventStream;
+  config?: Partial<DetectConfig>;
+}
+
+export class FrameLoop {
+  private readonly session: PerceptionSession;
+  private readonly frameCapture: FrameCapture;
+  private readonly eventStream: TemporalEventStream;
+  private readonly config: DetectConfig;
+
+  private activeAnimations = new Set<string>();
+  private recentMutations: TimelineEvent<'mutation'>[] = [];
+  private lastAnomalyEmittedAt = -Infinity;
+
+  // Bound handlers so we can remove them in stop()
+  private readonly onKeyframe = (kf: { frame: Buffer; timestamp: number }): void => {
+    this.handleKeyframe(kf.timestamp);
+  };
+  private readonly onEvent = (e: TimelineEvent<EventType>): void => {
+    this.handleEvent(e);
+  };
+
+  constructor(opts: FrameLoopOptions) {
+    this.session = opts.session;
+    this.frameCapture = opts.frameCapture;
+    this.eventStream = opts.eventStream;
+    this.config = { ...DEFAULT_CONFIG, ...opts.config };
+  }
+
+  start(): void {
+    this.frameCapture.on('keyframe', this.onKeyframe);
+    this.eventStream.on('event', this.onEvent);
+  }
+
+  stop(): void {
+    this.frameCapture.off('keyframe', this.onKeyframe);
+    this.eventStream.off('event', this.onEvent);
+    this.activeAnimations.clear();
+    this.recentMutations = [];
+  }
+
+  /** Test seam: expose state for assertions. */
+  getActiveAnimationsForTest(): Set<string> {
+    return this.activeAnimations;
+  }
+
+  /** Test seam. */
+  getRecentMutationsForTest(): TimelineEvent<'mutation'>[] {
+    return this.recentMutations;
+  }
+
+  private handleEvent(e: TimelineEvent<EventType>): void {
+    if (e.type === 'animation-start') {
+      const payload = e.payload as TimelineEvent<'animation-start'>['payload'];
+      this.activeAnimations.add(payload.animationId);
+    } else if (e.type === 'animation-end') {
+      const payload = e.payload as TimelineEvent<'animation-end'>['payload'];
+      this.activeAnimations.delete(payload.animationId);
+    } else if (e.type === 'mutation') {
+      this.recentMutations.push(e as TimelineEvent<'mutation'>);
+    }
+  }
+
+  private handleKeyframe(nowMs: number): void {
+    // Trim ring buffer to lookback window
+    this.recentMutations = this.recentMutations.filter(
+      (m) => nowMs - m.timestamp <= this.config.lookbackMs,
+    );
+
+    // Emit the frame tick
+    this.session.recordTick('frame', 'keyframe', nowMs);
+
+    // Debounce: skip detector if we just emitted within the coalesce window
+    if (nowMs - this.lastAnomalyEmittedAt <= this.config.coalesceWindowMs) {
+      return;
+    }
+
+    const result = detectMutationOutsideAnimation(
+      {
+        recentMutations: this.recentMutations,
+        activeAnimations: this.activeAnimations,
+        nowMs,
+        sessionStartMs: this.session.getStartedAt(),
+      },
+      this.config,
+    );
+
+    if (!result) return;
+
+    this.lastAnomalyEmittedAt = nowMs;
+
+    // Best-effort: pull bboxes from mutation payloads if available; otherwise use null bbox.
+    // Mutation payloads don't carry bboxes today, so for v1 we emit nodeIds without bboxes;
+    // the semantic loop is responsible for resolving bboxes from the structural pipeline.
+    const regions = result.targetNodeIds.map((nodeId) => ({
+      nodeId,
+      bbox: { x: 0, y: 0, w: 0, h: 0 },
+    }));
+
+    this.session.recordAnomaly('frame', 'mutation-outside-animation', result, nowMs);
+    this.session.recordEscalation('frame', 'semantic', 'mutation-outside-animation', regions, nowMs);
+    this.session.internalEmitter.emit('escalate', { from: 'frame', regions });
+  }
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+pnpm exec vitest run --reporter=verbose tests/unit/pipelines/perception/frame-loop.test.ts
+```
+Expected: 7 passing.
+
+- [ ] **Step 6: Typecheck**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pipelines/perception/frame-loop.ts tests/unit/pipelines/perception/frame-loop.test.ts
+git commit -m "feat(perception): FrameLoop — keyframe subscriber + detector wiring"
+```
+
+---
+
+## Task 5: `SemanticLoop`
+
+**Files:**
+- Create: `src/pipelines/perception/semantic-loop.ts`
+- Create: `tests/unit/pipelines/perception/semantic-loop.test.ts`
+
+Cadence-bounded loop that wakes on escalation from frame loop or on heartbeat-with-pending-work. On wake: re-runs structural extraction + the #4 `Indexer`, then checks for `component.status === 'pending'` nodes and escalates to intent.
+
+**Simplification for v1:** Semantic loop re-runs the *full* structural pipeline + `Indexer.run()` on each wake (not just the changed subtree). Captured in the spec's open questions as a perf follow-up.
+
+- [ ] **Step 1: Write `tests/unit/pipelines/perception/semantic-loop.test.ts`**
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SemanticLoop } from '../../../../src/pipelines/perception/semantic-loop.js';
+import { PerceptionSession } from '../../../../src/pipelines/perception/session.js';
+import type { TemporalEventStream } from '../../../../src/pipelines/temporal/event-stream.js';
+import type { StructuralPipeline } from '../../../../src/pipelines/structural/index.js';
+import type { Indexer } from '../../../../src/pipelines/component-index/indexer.js';
+import type { Page } from 'playwright';
+
+function mkSession() {
+  const stream = { recordEvent: vi.fn(), on: vi.fn(), off: vi.fn() } as unknown as TemporalEventStream;
+  return { session: new PerceptionSession({ eventStream: stream }), stream };
+}
+
+function mkIndexer(componentMap: Map<string, any>): Indexer {
+  return {
+    run: vi.fn(async () => componentMap),
+  } as unknown as Indexer;
+}
+
+function mkStructural(nodes: any[]): StructuralPipeline {
+  return {
+    extractStructure: vi.fn(async () => nodes),
+  } as unknown as StructuralPipeline;
+}
+
+function mkPage(): Page {
+  return {
+    url: () => 'http://test',
+  } as unknown as Page;
+}
+
+describe('SemanticLoop', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('does not tick when idle (no escalations, heartbeat fires but queue empty)', () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const indexer = mkIndexer(new Map());
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream,
+      indexer,
+      structuralPipeline: mkStructural([]),
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+    vi.advanceTimersByTime(500);
+    const tickCalls = (stream.recordEvent as any).mock.calls.filter((c: any[]) => c[0] === 'perception-tick' && c[1].tier === 'semantic');
+    expect(tickCalls).toHaveLength(0);
+  });
+
+  it('wakes on escalation and emits a semantic tick', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const indexer = mkIndexer(new Map());
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream,
+      indexer,
+      structuralPipeline: mkStructural([]),
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+    session.internalEmitter.emit('escalate', { from: 'frame', regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }] });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(stream.recordEvent).toHaveBeenCalledWith(
+      'perception-tick',
+      expect.objectContaining({ tier: 'semantic', cause: 'escalation' }),
+      expect.any(Number),
+    );
+  });
+
+  it('rate-bounds: two escalations within cadenceMs produce one tick', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const indexer = mkIndexer(new Map());
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream,
+      indexer,
+      structuralPipeline: mkStructural([]),
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+    session.internalEmitter.emit('escalate', { from: 'frame', regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }] });
+    await vi.advanceTimersByTimeAsync(50);
+    session.internalEmitter.emit('escalate', { from: 'frame', regions: [{ nodeId: 'b', bbox: { x: 0, y: 0, w: 10, h: 10 } }] });
+    await vi.advanceTimersByTimeAsync(50);
+    const tickCalls = (stream.recordEvent as any).mock.calls.filter((c: any[]) => c[0] === 'perception-tick' && c[1].tier === 'semantic');
+    expect(tickCalls).toHaveLength(1);
+  });
+
+  it('calls indexer.run on each tick', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const indexer = mkIndexer(new Map());
+    const structural = mkStructural([{ id: 'n-1', tag: 'div' }]);
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream,
+      indexer,
+      structuralPipeline: structural,
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+    session.internalEmitter.emit('escalate', { from: 'frame', regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }] });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(structural.extractStructure).toHaveBeenCalled();
+    expect(indexer.run).toHaveBeenCalled();
+  });
+
+  it('escalates to intent when indexer flags a node as pending', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const componentMap = new Map([
+      ['a', { name: null, status: 'pending', signature: 'sig-1' }],
+    ]);
+    const indexer = mkIndexer(componentMap);
+    const structural = mkStructural([{ id: 'a', tag: 'div', boundingBox: { x: 0, y: 0, width: 100, height: 50 } }]);
+
+    const intentHandler = vi.fn();
+    session.internalEmitter.on('escalate', (payload) => {
+      if (payload.from === 'semantic') intentHandler(payload);
+    });
+
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream,
+      indexer,
+      structuralPipeline: structural,
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+    session.internalEmitter.emit('escalate', { from: 'frame', regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 100, h: 50 } }] });
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(intentHandler).toHaveBeenCalledWith(expect.objectContaining({ from: 'semantic' }));
+    expect(stream.recordEvent).toHaveBeenCalledWith(
+      'perception-escalation',
+      expect.objectContaining({ from: 'semantic', to: 'intent' }),
+      expect.any(Number),
+    );
+  });
+
+  it('does not escalate to intent when no nodes are pending', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const componentMap = new Map([
+      ['a', { name: 'Button', source: 'rules', signature: 'sig-1' }],
+    ]);
+    const indexer = mkIndexer(componentMap);
+    const structural = mkStructural([{ id: 'a', tag: 'button', boundingBox: { x: 0, y: 0, width: 100, height: 50 } }]);
+
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream,
+      indexer,
+      structuralPipeline: structural,
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+    session.internalEmitter.emit('escalate', { from: 'frame', regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 100, h: 50 } }] });
+    await vi.advanceTimersByTimeAsync(10);
+
+    const escalationCalls = (stream.recordEvent as any).mock.calls.filter(
+      (c: any[]) => c[0] === 'perception-escalation' && c[1].from === 'semantic',
+    );
+    expect(escalationCalls).toHaveLength(0);
+  });
+
+  it('stop() unsubscribes', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream,
+      indexer: mkIndexer(new Map()),
+      structuralPipeline: mkStructural([]),
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+    loop.stop();
+    session.internalEmitter.emit('escalate', { from: 'frame', regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }] });
+    await vi.advanceTimersByTimeAsync(10);
+    const tickCalls = (stream.recordEvent as any).mock.calls.filter((c: any[]) => c[0] === 'perception-tick' && c[1].tier === 'semantic');
+    expect(tickCalls).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run — should FAIL (module not found)**
+
+```bash
+pnpm exec vitest run --reporter=verbose tests/unit/pipelines/perception/semantic-loop.test.ts
+```
+
+- [ ] **Step 3: Create `src/pipelines/perception/semantic-loop.ts`**
+
+```typescript
+import type { Page } from 'playwright';
+import type { StructuralPipeline } from '../structural/index.js';
+import type { Indexer } from '../component-index/indexer.js';
+import type { TemporalEventStream } from '../temporal/event-stream.js';
+import type { PerceptionSession } from './session.js';
+
+export interface SemanticLoopOptions {
+  session: PerceptionSession;
+  eventStream: TemporalEventStream;
+  indexer: Indexer;
+  structuralPipeline: StructuralPipeline;
+  page: Page;
+  config?: { cadenceMs?: number };
+}
+
+interface PendingEscalation {
+  regions: Array<{ nodeId: string; bbox: { x: number; y: number; w: number; h: number } }>;
+}
+
+export class SemanticLoop {
+  private readonly session: PerceptionSession;
+  private readonly indexer: Indexer;
+  private readonly structuralPipeline: StructuralPipeline;
+  private readonly page: Page;
+  private readonly cadenceMs: number;
+
+  private pending: PendingEscalation[] = [];
+  private lastTickAt = -Infinity;
+  private running = false;
+
+  private readonly onEscalate = (payload: { from: string; regions: PendingEscalation['regions'] }): void => {
+    if (payload.from !== 'frame') return;
+    this.pending.push({ regions: payload.regions });
+    void this.maybeWake('escalation');
+  };
+
+  constructor(opts: SemanticLoopOptions) {
+    this.session = opts.session;
+    this.indexer = opts.indexer;
+    this.structuralPipeline = opts.structuralPipeline;
+    this.page = opts.page;
+    this.cadenceMs = opts.config?.cadenceMs ?? 200;
+  }
+
+  start(): void {
+    this.running = true;
+    this.session.internalEmitter.on('escalate', this.onEscalate);
+  }
+
+  stop(): void {
+    this.running = false;
+    this.session.internalEmitter.off('escalate', this.onEscalate);
+    this.pending = [];
+  }
+
+  private async maybeWake(cause: 'escalation' | 'heartbeat'): Promise<void> {
+    if (!this.running) return;
+    const now = Date.now();
+    if (now - this.lastTickAt < this.cadenceMs) return;
+    if (this.pending.length === 0 && cause === 'heartbeat') return;
+
+    this.lastTickAt = now;
+    const work = this.pending;
+    this.pending = [];
+
+    this.session.recordTick('semantic', cause, now);
+
+    // Re-extract structural state + run indexer (v1: full re-extraction)
+    const structural = await this.structuralPipeline.extractStructure(this.page);
+    const url = this.page.url();
+    const origin = safeOrigin(url);
+    const componentMap = await this.indexer.run(structural, { origin });
+
+    // Collect pending-classification nodes referenced by the flagged regions
+    const flaggedIds = new Set<string>();
+    for (const escalation of work) {
+      for (const region of escalation.regions) flaggedIds.add(region.nodeId);
+    }
+
+    const pendingRegions: Array<{ nodeId: string; bbox: { x: number; y: number; w: number; h: number } }> = [];
+    for (const nodeId of flaggedIds) {
+      const entry = componentMap.get(nodeId);
+      if (entry && entry.name === null && entry.status === 'pending') {
+        const node = structural.find((n) => n.id === nodeId);
+        const bb = node?.boundingBox ?? { x: 0, y: 0, width: 0, height: 0 };
+        pendingRegions.push({
+          nodeId,
+          bbox: { x: bb.x, y: bb.y, w: bb.width, h: bb.height },
+        });
+      }
+    }
+
+    if (pendingRegions.length > 0) {
+      this.session.recordEscalation('semantic', 'intent', 'mutation-outside-animation', pendingRegions, now);
+      this.session.internalEmitter.emit('escalate', { from: 'semantic', regions: pendingRegions });
+    }
+  }
+}
+
+function safeOrigin(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return url;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm exec vitest run --reporter=verbose tests/unit/pipelines/perception/semantic-loop.test.ts
+```
+Expected: 7 passing.
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pipelines/perception/semantic-loop.ts tests/unit/pipelines/perception/semantic-loop.test.ts
+git commit -m "feat(perception): SemanticLoop — escalation-driven, calls Indexer, escalates to intent"
+```
+
+---
+
+## Task 6: `IntentLoop`
+
+**Files:**
+- Create: `src/pipelines/perception/intent-loop.ts`
+- Create: `tests/unit/pipelines/perception/intent-loop.test.ts`
+
+Pure event-driven loop. Wakes only on escalation from semantic. Crops the latest screenshot to each region's bbox via `sharp`, calls `classifyByVlm`, emits `perception-intent-result`. Maintains an internal pending queue with backpressure (drop oldest after `maxPending`).
+
+**`classifyByVlm` is injected** via constructor so tests can mock without hitting Anthropic. Same pattern as #4's queue tests.
+
+**Screenshot source:** the loop takes a `getScreenshot: () => Promise<Buffer | null>` callback in its constructor. The session provides this as `() => page.screenshot().catch(() => null)`. In tests, it's a `vi.fn()` returning a fake PNG buffer.
+
+- [ ] **Step 1: Write `tests/unit/pipelines/perception/intent-loop.test.ts`**
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { IntentLoop } from '../../../../src/pipelines/perception/intent-loop.js';
+import { PerceptionSession } from '../../../../src/pipelines/perception/session.js';
+import type { TemporalEventStream } from '../../../../src/pipelines/temporal/event-stream.js';
+
+vi.mock('sharp', () => {
+  // Stub: extract().png().toBuffer() returns the input buffer unchanged
+  const extract = vi.fn().mockReturnThis();
+  const png = vi.fn().mockReturnThis();
+  const toBuffer = vi.fn(async () => Buffer.from([0x89, 0x50]));
+  return {
+    default: () => ({ extract, png, toBuffer }),
+  };
+});
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+
+function mkSession() {
+  const stream = { recordEvent: vi.fn(), on: vi.fn(), off: vi.fn() } as unknown as TemporalEventStream;
+  return { session: new PerceptionSession({ eventStream: stream }), stream };
+}
+
+describe('IntentLoop', () => {
+  it('does not call VLM unless an escalation arrives', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const classify = vi.fn(async () => 'X');
+    const getScreenshot = vi.fn(async () => PNG);
+    const loop = new IntentLoop({ session, eventStream: stream, getScreenshot, classifyByVlm: classify });
+    loop.start();
+    await Promise.resolve();
+    expect(classify).not.toHaveBeenCalled();
+  });
+
+  it('classifies each region in an escalation and emits perception-intent-result', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const classify = vi.fn(async () => 'AnimatedCounter');
+    const getScreenshot = vi.fn(async () => PNG);
+    const loop = new IntentLoop({ session, eventStream: stream, getScreenshot, classifyByVlm: classify });
+    loop.start();
+
+    session.internalEmitter.emit('escalate', {
+      from: 'semantic',
+      regions: [
+        { nodeId: 'a', bbox: { x: 0, y: 0, w: 50, h: 30 } },
+        { nodeId: 'b', bbox: { x: 60, y: 0, w: 50, h: 30 } },
+      ],
+    });
+
+    // Allow microtasks
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(classify).toHaveBeenCalledTimes(2);
+    const intentResultCalls = (stream.recordEvent as any).mock.calls.filter((c: any[]) => c[0] === 'perception-intent-result');
+    expect(intentResultCalls).toHaveLength(2);
+  });
+
+  it('emits a single perception-tick for the drain (not per-region)', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const classify = vi.fn(async () => 'X');
+    const getScreenshot = vi.fn(async () => PNG);
+    const loop = new IntentLoop({ session, eventStream: stream, getScreenshot, classifyByVlm: classify });
+    loop.start();
+    session.internalEmitter.emit('escalate', {
+      from: 'semantic',
+      regions: [
+        { nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } },
+        { nodeId: 'b', bbox: { x: 20, y: 0, w: 10, h: 10 } },
+      ],
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    const tickCalls = (stream.recordEvent as any).mock.calls.filter((c: any[]) => c[0] === 'perception-tick' && c[1].tier === 'intent');
+    expect(tickCalls).toHaveLength(1);
+  });
+
+  it('drops oldest when pending queue exceeds maxPending', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    // Make classify slow so the queue builds up
+    let resolveClassify: (v: string) => void = () => {};
+    const classify = vi.fn(() => new Promise<string>((r) => { resolveClassify = r; }));
+    const getScreenshot = vi.fn(async () => PNG);
+    const loop = new IntentLoop({ session, eventStream: stream, getScreenshot, classifyByVlm: classify, config: { maxPending: 2 } });
+    loop.start();
+
+    // Fire 5 escalations — first starts immediately, next ones queue, exceeding maxPending=2
+    for (let i = 0; i < 5; i++) {
+      session.internalEmitter.emit('escalate', { from: 'semantic', regions: [{ nodeId: `n-${i}`, bbox: { x: 0, y: 0, w: 10, h: 10 } }] });
+    }
+    await Promise.resolve();
+
+    // Resolve in-flight + drain
+    resolveClassify('X');
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Behavior: oldest got dropped. We assert exact count is finite and < 5.
+    const intentResultCalls = (stream.recordEvent as any).mock.calls.filter((c: any[]) => c[0] === 'perception-intent-result');
+    expect(intentResultCalls.length).toBeLessThan(5);
+  });
+
+  it('skips classification when screenshot provider returns null', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const classify = vi.fn(async () => 'X');
+    const getScreenshot = vi.fn(async () => null);
+    const loop = new IntentLoop({ session, eventStream: stream, getScreenshot, classifyByVlm: classify });
+    loop.start();
+    session.internalEmitter.emit('escalate', { from: 'semantic', regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }] });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(classify).not.toHaveBeenCalled();
+  });
+
+  it('continues past a per-region classifier error', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const classify = vi.fn()
+      .mockImplementationOnce(async () => { throw new Error('boom'); })
+      .mockImplementationOnce(async () => 'OK');
+    const getScreenshot = vi.fn(async () => PNG);
+    const loop = new IntentLoop({ session, eventStream: stream, getScreenshot, classifyByVlm: classify });
+    loop.start();
+    session.internalEmitter.emit('escalate', {
+      from: 'semantic',
+      regions: [
+        { nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } },
+        { nodeId: 'b', bbox: { x: 20, y: 0, w: 10, h: 10 } },
+      ],
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    const successfulCalls = (stream.recordEvent as any).mock.calls.filter(
+      (c: any[]) => c[0] === 'perception-intent-result' && c[1].classification === 'OK',
+    );
+    expect(successfulCalls).toHaveLength(1);
+  });
+
+  it('ignores escalation events whose from is not semantic', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const classify = vi.fn(async () => 'X');
+    const getScreenshot = vi.fn(async () => PNG);
+    const loop = new IntentLoop({ session, eventStream: stream, getScreenshot, classifyByVlm: classify });
+    loop.start();
+    session.internalEmitter.emit('escalate', { from: 'frame', regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }] });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(classify).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run — should FAIL (module not found)**
+
+```bash
+pnpm exec vitest run --reporter=verbose tests/unit/pipelines/perception/intent-loop.test.ts
+```
+
+- [ ] **Step 3: Create `src/pipelines/perception/intent-loop.ts`**
+
+```typescript
+import sharp from 'sharp';
+import { createLogger } from '../../utils/logger.js';
+import type { TemporalEventStream } from '../temporal/event-stream.js';
+import type { PerceptionSession } from './session.js';
+
+const logger = createLogger('PerceptionIntentLoop');
+
+export type ClassifyByVlmFn = (args: { html: string; screenshotCrop: Buffer }) => Promise<string>;
+
+export interface IntentLoopOptions {
+  session: PerceptionSession;
+  eventStream: TemporalEventStream;
+  getScreenshot: () => Promise<Buffer | null>;
+  classifyByVlm: ClassifyByVlmFn;
+  config?: { maxPending?: number };
+}
+
+interface PendingItem {
+  nodeId: string;
+  bbox: { x: number; y: number; w: number; h: number };
+}
+
+export class IntentLoop {
+  private readonly session: PerceptionSession;
+  private readonly getScreenshot: () => Promise<Buffer | null>;
+  private readonly classify: ClassifyByVlmFn;
+  private readonly maxPending: number;
+
+  private pending: PendingItem[] = [];
+  private draining = false;
+  private running = false;
+
+  private readonly onEscalate = (payload: { from: string; regions: PendingItem[] }): void => {
+    if (payload.from !== 'semantic') return;
+    for (const region of payload.regions) this.enqueue(region);
+    void this.drain();
+  };
+
+  constructor(opts: IntentLoopOptions) {
+    this.session = opts.session;
+    this.getScreenshot = opts.getScreenshot;
+    this.classify = opts.classifyByVlm;
+    this.maxPending = opts.config?.maxPending ?? 10;
+  }
+
+  start(): void {
+    this.running = true;
+    this.session.internalEmitter.on('escalate', this.onEscalate);
+  }
+
+  stop(): void {
+    this.running = false;
+    this.session.internalEmitter.off('escalate', this.onEscalate);
+    this.pending = [];
+  }
+
+  private enqueue(item: PendingItem): void {
+    if (this.pending.length >= this.maxPending) {
+      const dropped = this.pending.shift();
+      logger.warn('IntentLoop: dropping oldest pending region due to backpressure', { dropped });
+    }
+    this.pending.push(item);
+  }
+
+  private async drain(): Promise<void> {
+    if (this.draining) return;
+    if (this.pending.length === 0) return;
+    this.draining = true;
+    try {
+      // Single tick per drain
+      const tickAt = Date.now();
+      this.session.recordTick('intent', 'escalation', tickAt);
+
+      const screenshot = await this.getScreenshot();
+      if (!screenshot) {
+        this.pending = [];
+        return;
+      }
+
+      const items = this.pending;
+      this.pending = [];
+
+      for (const item of items) {
+        if (!this.running) break;
+        const start = Date.now();
+        try {
+          const crop = await cropToBbox(screenshot, item.bbox);
+          const classification = await this.classify({ html: '', screenshotCrop: crop });
+          const duration = Date.now() - start;
+          this.session.recordIntentResult(
+            { nodeId: item.nodeId, bbox: item.bbox },
+            classification,
+            duration,
+            Date.now(),
+          );
+        } catch (err) {
+          logger.warn('IntentLoop: per-region classification failed, skipping', { nodeId: item.nodeId, error: String(err) });
+        }
+      }
+    } finally {
+      this.draining = false;
+      // If new items arrived during drain, kick off another round.
+      if (this.pending.length > 0 && this.running) {
+        void this.drain();
+      }
+    }
+  }
+}
+
+async function cropToBbox(png: Buffer, bbox: { x: number; y: number; w: number; h: number }): Promise<Buffer> {
+  const left = Math.max(0, Math.round(bbox.x));
+  const top = Math.max(0, Math.round(bbox.y));
+  const width = Math.max(1, Math.round(bbox.w));
+  const height = Math.max(1, Math.round(bbox.h));
+  return sharp(png).extract({ left, top, width, height }).png().toBuffer();
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm exec vitest run --reporter=verbose tests/unit/pipelines/perception/intent-loop.test.ts
+```
+Expected: 7 passing.
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pipelines/perception/intent-loop.ts tests/unit/pipelines/perception/intent-loop.test.ts
+git commit -m "feat(perception): IntentLoop — escalation-driven VLM with backpressure"
+```
+
+---
+
+## Task 7: Wire loops into `PerceptionSession`
+
+**Files:**
+- Modify: `src/pipelines/perception/session.ts`
+- Modify: `tests/unit/pipelines/perception/session.test.ts`
+
+Extends `PerceptionSession.start()` to also instantiate and start all three loops; `stop()` stops them all. Also wires page navigation + close handling. The three loops are constructed inside `start()` because they depend on the page + collectors.
+
+The session's `start(page, deps)` signature changes — `start()` now takes the runtime dependencies (page, frameCapture, eventStream-already-known, indexer, structuralPipeline, classifyByVlm, getScreenshot).
+
+- [ ] **Step 1: Extend `tests/unit/pipelines/perception/session.test.ts` with composition tests**
+
+Add after the existing tests:
+
+```typescript
+import { FrameLoop } from '../../../../src/pipelines/perception/frame-loop.js';
+import { SemanticLoop } from '../../../../src/pipelines/perception/semantic-loop.js';
+import { IntentLoop } from '../../../../src/pipelines/perception/intent-loop.js';
+import { EventEmitter as NodeEventEmitter } from 'node:events';
+
+describe('PerceptionSession composed with loops', () => {
+  function mkComposedDeps() {
+    const stream = new NodeEventEmitter() as any;
+    stream.recordEvent = vi.fn();
+    const frameCapture = new NodeEventEmitter() as any;
+    const indexer = { run: vi.fn(async () => new Map()) } as any;
+    const structuralPipeline = { extractStructure: vi.fn(async () => []) } as any;
+    const page = {
+      url: () => 'http://test',
+      on: vi.fn(),
+      off: vi.fn(),
+    } as any;
+    const classifyByVlm = vi.fn(async () => 'X');
+    const getScreenshot = vi.fn(async () => Buffer.from([0x89, 0x50]));
+    return { stream, frameCapture, indexer, structuralPipeline, page, classifyByVlm, getScreenshot };
+  }
+
+  it('start() instantiates and starts FrameLoop, SemanticLoop, IntentLoop', () => {
+    const deps = mkComposedDeps();
+    const session = new PerceptionSession({ eventStream: deps.stream });
+    session.start(0, {
+      page: deps.page,
+      frameCapture: deps.frameCapture,
+      indexer: deps.indexer,
+      structuralPipeline: deps.structuralPipeline,
+      classifyByVlm: deps.classifyByVlm,
+      getScreenshot: deps.getScreenshot,
+    });
+    expect(deps.page.on).toHaveBeenCalledWith('framenavigated', expect.any(Function));
+    expect(deps.page.on).toHaveBeenCalledWith('close', expect.any(Function));
+    session.stop(100);
+  });
+
+  it('stop() cleanly removes page listeners', () => {
+    const deps = mkComposedDeps();
+    const session = new PerceptionSession({ eventStream: deps.stream });
+    session.start(0, {
+      page: deps.page,
+      frameCapture: deps.frameCapture,
+      indexer: deps.indexer,
+      structuralPipeline: deps.structuralPipeline,
+      classifyByVlm: deps.classifyByVlm,
+      getScreenshot: deps.getScreenshot,
+    });
+    session.stop(100);
+    expect(deps.page.off).toHaveBeenCalledWith('framenavigated', expect.any(Function));
+    expect(deps.page.off).toHaveBeenCalledWith('close', expect.any(Function));
+  });
+
+  it('navigation event resets sessionStartMs and emits a navigation-reset tick', () => {
+    const deps = mkComposedDeps();
+    const session = new PerceptionSession({ eventStream: deps.stream });
+    session.start(0, {
+      page: deps.page,
+      frameCapture: deps.frameCapture,
+      indexer: deps.indexer,
+      structuralPipeline: deps.structuralPipeline,
+      classifyByVlm: deps.classifyByVlm,
+      getScreenshot: deps.getScreenshot,
+    });
+    // Find and invoke the framenavigated handler
+    const navHandler = deps.page.on.mock.calls.find((c: any[]) => c[0] === 'framenavigated')[1];
+    navHandler();
+    expect(deps.stream.recordEvent).toHaveBeenCalledWith(
+      'perception-tick',
+      expect.objectContaining({ tier: 'frame', cause: 'navigation-reset' }),
+      expect.any(Number),
+    );
+    session.stop(100);
+  });
+
+  it('page close auto-stops the session', () => {
+    const deps = mkComposedDeps();
+    const session = new PerceptionSession({ eventStream: deps.stream });
+    session.start(0, {
+      page: deps.page,
+      frameCapture: deps.frameCapture,
+      indexer: deps.indexer,
+      structuralPipeline: deps.structuralPipeline,
+      classifyByVlm: deps.classifyByVlm,
+      getScreenshot: deps.getScreenshot,
+    });
+    const closeHandler = deps.page.on.mock.calls.find((c: any[]) => c[0] === 'close')[1];
+    closeHandler();
+    expect(session.isRunning()).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Modify `src/pipelines/perception/session.ts`**
+
+Add the imports at the top:
+```typescript
+import type { Page } from 'playwright';
+import type { FrameCapture } from '../visual/frame-capture.js';
+import type { StructuralPipeline } from '../structural/index.js';
+import type { Indexer } from '../component-index/indexer.js';
+import { FrameLoop } from './frame-loop.js';
+import { SemanticLoop } from './semantic-loop.js';
+import { IntentLoop, type ClassifyByVlmFn } from './intent-loop.js';
+```
+
+Replace the `start(nowMs: number)` method signature and body with:
+```typescript
+export interface SessionStartDeps {
+  page: Page;
+  frameCapture: FrameCapture;
+  indexer: Indexer;
+  structuralPipeline: StructuralPipeline;
+  classifyByVlm: ClassifyByVlmFn;
+  getScreenshot: () => Promise<Buffer | null>;
+}
+
+// ... inside class:
+
+private frameLoop: FrameLoop | null = null;
+private semanticLoop: SemanticLoop | null = null;
+private intentLoop: IntentLoop | null = null;
+private page: Page | null = null;
+private readonly onPageNav = (): void => {
+  const now = Date.now();
+  this.resetStartedAt(now);
+  this.stream.recordEvent('perception-tick', { tier: 'frame', cause: 'navigation-reset' }, now);
+};
+private readonly onPageClose = (): void => {
+  if (this.isRunning()) {
+    try { this.stop(Date.now()); } catch { /* already stopped */ }
+  }
+};
+
+start(nowMs: number, deps?: SessionStartDeps): void {
+  if (this.state === 'running') {
+    throw new Error('PerceptionSession.start: already running');
+  }
+  this.state = 'running';
+  this.startedAt = nowMs;
+  this.stoppedAt = 0;
+
+  if (deps) {
+    this.page = deps.page;
+    this.frameLoop = new FrameLoop({ session: this, frameCapture: deps.frameCapture, eventStream: this.stream });
+    this.semanticLoop = new SemanticLoop({
+      session: this,
+      eventStream: this.stream,
+      indexer: deps.indexer,
+      structuralPipeline: deps.structuralPipeline,
+      page: deps.page,
+    });
+    this.intentLoop = new IntentLoop({
+      session: this,
+      eventStream: this.stream,
+      classifyByVlm: deps.classifyByVlm,
+      getScreenshot: deps.getScreenshot,
+    });
+    this.frameLoop.start();
+    this.semanticLoop.start();
+    this.intentLoop.start();
+    deps.page.on('framenavigated', this.onPageNav);
+    deps.page.on('close', this.onPageClose);
+  }
+}
+
+stop(nowMs: number): void {
+  if (this.state !== 'running') {
+    throw new Error('PerceptionSession.stop: not running');
+  }
+  this.state = 'stopped';
+  this.stoppedAt = nowMs;
+  this.frameLoop?.stop();
+  this.semanticLoop?.stop();
+  this.intentLoop?.stop();
+  this.frameLoop = null;
+  this.semanticLoop = null;
+  this.intentLoop = null;
+  if (this.page) {
+    this.page.off('framenavigated', this.onPageNav);
+    this.page.off('close', this.onPageClose);
+    this.page = null;
+  }
+  this.internalEmitter.removeAllListeners();
+}
+```
+
+- [ ] **Step 3: Run all perception unit tests**
+
+```bash
+pnpm exec vitest run --reporter=verbose tests/unit/pipelines/perception/
+```
+Expected: previously-passing tests still pass + 4 new session composition tests.
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pipelines/perception/session.ts tests/unit/pipelines/perception/session.test.ts
+git commit -m "feat(perception): wire loops into PerceptionSession + page nav/close handlers"
+```
+
+---
+
+## Task 8: MCP tools + server wiring
+
+**Files:**
+- Create: `src/mcp/tools/perception.ts`
+- Create: `tests/unit/mcp/perception.test.ts`
+- Modify: `src/mcp/server.ts`
+- Modify: `tests/unit/mcp/tools.test.ts`
+
+Three new MCP tools that share state. Following the file-per-tool pattern from `#4`'s `get-component-index.ts` would mean three separate files; here we put them in one file (`perception.ts`) because they share a `PerceptionToolState` object — three factories closing over the same state is cleaner than three files reaching into a shared module.
+
+- [ ] **Step 1: Write `tests/unit/mcp/perception.test.ts`**
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createPerceptionState,
+  makeStartPerceptionTool,
+  makeStopPerceptionTool,
+  makeGetPerceptionSessionTool,
+} from '../../../src/mcp/tools/perception.js';
+
+function mkDeps() {
+  const session = {
+    isRunning: vi.fn(() => false),
+    start: vi.fn(),
+    stop: vi.fn(),
+    getSummary: vi.fn(() => ({ startedAt: 100, durationMs: 0, tickCounts: { frame: 0, semantic: 0, intent: 0 } } as any)),
+    getStartedAt: vi.fn(() => 100),
+  };
+  const ensureLaunched = vi.fn(async () => {});
+  const ensureWatchStarted = vi.fn(async () => {});
+  const getPage = vi.fn(() => ({ url: () => 'http://x', on: vi.fn(), off: vi.fn() } as any));
+  const getDeps = vi.fn(() => ({
+    page: getPage(),
+    frameCapture: {} as any,
+    indexer: {} as any,
+    structuralPipeline: {} as any,
+    classifyByVlm: vi.fn() as any,
+    getScreenshot: vi.fn() as any,
+  }));
+  return { session, ensureLaunched, ensureWatchStarted, getPage, getDeps };
+}
+
+describe('start_perception', () => {
+  it('starts a session and reports startedAt', async () => {
+    const deps = mkDeps();
+    const state = createPerceptionState();
+    state.createSession = vi.fn(() => deps.session as any);
+    const tool = makeStartPerceptionTool({
+      state,
+      ensureLaunched: deps.ensureLaunched,
+      ensureWatchStarted: deps.ensureWatchStarted,
+      getSessionDeps: deps.getDeps,
+    });
+    const result = await tool.handler({});
+    expect(result).toEqual({ status: 'started', startedAt: expect.any(Number) });
+    expect(deps.ensureWatchStarted).toHaveBeenCalled();
+    expect(deps.session.start).toHaveBeenCalled();
+  });
+
+  it('returns already-running if called twice', async () => {
+    const deps = mkDeps();
+    const state = createPerceptionState();
+    deps.session.isRunning = vi.fn(() => true);
+    state.currentSession = deps.session as any;
+    const tool = makeStartPerceptionTool({
+      state,
+      ensureLaunched: deps.ensureLaunched,
+      ensureWatchStarted: deps.ensureWatchStarted,
+      getSessionDeps: deps.getDeps,
+    });
+    const result = await tool.handler({});
+    expect(result).toEqual({ status: 'already-running', startedAt: 100 });
+  });
+});
+
+describe('stop_perception', () => {
+  it('returns summary and clears current session', async () => {
+    const deps = mkDeps();
+    deps.session.isRunning = vi.fn(() => true);
+    const state = createPerceptionState();
+    state.currentSession = deps.session as any;
+    const tool = makeStopPerceptionTool({ state });
+    const result = await tool.handler({});
+    expect(deps.session.stop).toHaveBeenCalled();
+    expect(state.currentSession).toBeNull();
+    expect((result as any).startedAt).toBe(100);
+  });
+
+  it('returns the lastSummary if no session is running', async () => {
+    const state = createPerceptionState();
+    state.lastSummary = { startedAt: 50, durationMs: 200 } as any;
+    const tool = makeStopPerceptionTool({ state });
+    const result = await tool.handler({});
+    expect((result as any).startedAt).toBe(50);
+  });
+
+  it('returns an error if no session and no last summary', async () => {
+    const state = createPerceptionState();
+    const tool = makeStopPerceptionTool({ state });
+    const result = await tool.handler({});
+    expect((result as any).error).toMatch(/no session/i);
+  });
+});
+
+describe('get_perception_session', () => {
+  it('returns the running summary', async () => {
+    const deps = mkDeps();
+    deps.session.isRunning = vi.fn(() => true);
+    const state = createPerceptionState();
+    state.currentSession = deps.session as any;
+    const tool = makeGetPerceptionSessionTool({ state });
+    const result = await tool.handler({});
+    expect((result as any).startedAt).toBe(100);
+  });
+
+  it('falls back to last summary', async () => {
+    const state = createPerceptionState();
+    state.lastSummary = { startedAt: 33 } as any;
+    const tool = makeGetPerceptionSessionTool({ state });
+    const result = await tool.handler({});
+    expect((result as any).startedAt).toBe(33);
+  });
+});
+```
+
+- [ ] **Step 2: Create `src/mcp/tools/perception.ts`**
+
+```typescript
+import { PerceptionSession, type SessionStartDeps } from '../../pipelines/perception/session.js';
+import type { TemporalEventStream } from '../../pipelines/temporal/event-stream.js';
+import type { PerceptionSessionSummary } from '../../pipelines/perception/types.js';
+
+export interface PerceptionState {
+  currentSession: PerceptionSession | null;
+  lastSummary: PerceptionSessionSummary | null;
+  /** Test seam: factory for creating a new PerceptionSession. */
+  createSession: (eventStream: TemporalEventStream) => PerceptionSession;
+}
+
+export function createPerceptionState(): PerceptionState {
+  return {
+    currentSession: null,
+    lastSummary: null,
+    createSession: (eventStream) => new PerceptionSession({ eventStream }),
+  };
+}
+
+interface StartOptions {
+  state: PerceptionState;
+  ensureLaunched: () => Promise<void>;
+  ensureWatchStarted: () => Promise<void>;
+  getEventStream?: () => TemporalEventStream;
+  getSessionDeps: () => SessionStartDeps;
+}
+
+export interface StartPerceptionTool {
+  readonly name: 'start_perception';
+  readonly description: string;
+  readonly inputSchema: { type: 'object'; properties: Record<string, never>; required: never[] };
+  handler(args: Record<string, never>): Promise<{ status: 'started' | 'already-running'; startedAt: number }>;
+}
+
+export function makeStartPerceptionTool(opts: StartOptions): StartPerceptionTool {
+  return {
+    name: 'start_perception',
+    description:
+      'Begin a perception session. Starts the frame/semantic/intent loop hierarchy on the current page. Auto-starts watch (keyframe capture) if not already running. Use stop_perception to end the session and get a summary.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    async handler() {
+      const s = opts.state.currentSession;
+      if (s && s.isRunning()) {
+        return { status: 'already-running', startedAt: s.getStartedAt() };
+      }
+      await opts.ensureLaunched();
+      await opts.ensureWatchStarted();
+      const eventStream = opts.getEventStream?.();
+      const session = eventStream
+        ? opts.state.createSession(eventStream)
+        : opts.state.createSession(null as unknown as TemporalEventStream);
+      const deps = opts.getSessionDeps();
+      const startedAt = Date.now();
+      session.start(startedAt, deps);
+      opts.state.currentSession = session;
+      return { status: 'started', startedAt };
+    },
+  };
+}
+
+interface StopOptions {
+  state: PerceptionState;
+}
+
+export interface StopPerceptionTool {
+  readonly name: 'stop_perception';
+  readonly description: string;
+  readonly inputSchema: { type: 'object'; properties: Record<string, never>; required: never[] };
+  handler(args: Record<string, never>): Promise<PerceptionSessionSummary | { error: string }>;
+}
+
+export function makeStopPerceptionTool(opts: StopOptions): StopPerceptionTool {
+  return {
+    name: 'stop_perception',
+    description:
+      "End the current perception session and return its summary (tick counts, anomalies, escalations, intent results, VLM cost). Does NOT stop watch — keyframe capture continues for non-perception consumers. If no session is running, returns the previous session's summary if available.",
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    async handler() {
+      const session = opts.state.currentSession;
+      if (session && session.isRunning()) {
+        session.stop(Date.now());
+        const summary = session.getSummary();
+        opts.state.lastSummary = summary;
+        opts.state.currentSession = null;
+        return summary;
+      }
+      if (opts.state.lastSummary) {
+        return opts.state.lastSummary;
+      }
+      return { error: 'No session active and no prior summary' };
+    },
+  };
+}
+
+interface GetOptions {
+  state: PerceptionState;
+}
+
+export interface GetPerceptionSessionTool {
+  readonly name: 'get_perception_session';
+  readonly description: string;
+  readonly inputSchema: { type: 'object'; properties: Record<string, never>; required: never[] };
+  handler(args: Record<string, never>): Promise<PerceptionSessionSummary | { error: string }>;
+}
+
+export function makeGetPerceptionSessionTool(opts: GetOptions): GetPerceptionSessionTool {
+  return {
+    name: 'get_perception_session',
+    description:
+      "Return the current perception session's summary if one is running. Otherwise return the last completed session's summary if any. Use this to inspect what perception is seeing mid-flight without stopping the session.",
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    async handler() {
+      const session = opts.state.currentSession;
+      if (session && session.isRunning()) {
+        return session.getSummary();
+      }
+      if (opts.state.lastSummary) {
+        return opts.state.lastSummary;
+      }
+      return { error: 'No session active and no prior summary' };
+    },
+  };
+}
+```
+
+- [ ] **Step 3: Run the tool tests — should FAIL (module not found)**
+
+```bash
+pnpm exec vitest run --reporter=verbose tests/unit/mcp/perception.test.ts
+```
+
+- [ ] **Step 4: After creating the file in Step 2, re-run; expect 8 passing**
+
+```bash
+pnpm exec vitest run --reporter=verbose tests/unit/mcp/perception.test.ts
+```
+
+- [ ] **Step 5: Modify `src/mcp/server.ts` to wire the tools**
+
+Add to the imports block:
+```typescript
+import {
+  createPerceptionState,
+  makeStartPerceptionTool,
+  makeStopPerceptionTool,
+  makeGetPerceptionSessionTool,
+} from './tools/perception.js';
+import { classifyByVlm } from '../pipelines/component-index/vlm-classifier.js';
+```
+
+Add to the `TOOL_NAMES` array (after `'get_component_index'` or wherever the last tool is):
+```typescript
+  'start_perception',
+  'stop_perception',
+  'get_perception_session',
+```
+
+Inside `createServer`, after the `componentIndexer` initialization (added in #4 Task 10), instantiate the perception state:
+
+```typescript
+  const perceptionState = createPerceptionState();
+```
+
+And register the three tools. Find the existing `get_component_index` tool registration and add after it:
+
+```typescript
+  // Tool 15: start_perception
+  const startPerceptionTool = makeStartPerceptionTool({
+    state: perceptionState,
+    ensureLaunched,
+    ensureWatchStarted: async () => {
+      // If FrameCapture isn't running, start it. ensureWatchStarted mirrors the
+      // watch tool's behavior but does not return a result.
+      if (!frameCapture) {
+        await ensureLaunched();
+        const page = runtime.getPage();
+        frameCapture = new FrameCapture(page);
+        await frameCapture.start();
+        keyframeCount = 0;
+        watchStartTime = Date.now();
+      }
+    },
+    getEventStream: () => eventStream,
+    getSessionDeps: () => {
+      const page = runtime.getPage();
+      return {
+        page,
+        frameCapture: frameCapture!,
+        indexer: componentIndexer,
+        structuralPipeline: structural,
+        classifyByVlm,
+        getScreenshot: () => runtime.screenshot().catch(() => null),
+      };
+    },
+  });
+  server.registerTool(
+    startPerceptionTool.name,
+    {
+      title: 'Start Perception Session',
+      description: startPerceptionTool.description,
+      inputSchema: z.object({}),
+    },
+    async () => {
+      await ensureStreamAttached();
+      const result = await startPerceptionTool.handler({});
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // Tool 16: stop_perception
+  const stopPerceptionTool = makeStopPerceptionTool({ state: perceptionState });
+  server.registerTool(
+    stopPerceptionTool.name,
+    {
+      title: 'Stop Perception Session',
+      description: stopPerceptionTool.description,
+      inputSchema: z.object({}),
+    },
+    async () => {
+      const result = await stopPerceptionTool.handler({});
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // Tool 17: get_perception_session
+  const getPerceptionSessionTool = makeGetPerceptionSessionTool({ state: perceptionState });
+  server.registerTool(
+    getPerceptionSessionTool.name,
+    {
+      title: 'Get Perception Session',
+      description: getPerceptionSessionTool.description,
+      inputSchema: z.object({}),
+    },
+    async () => {
+      const result = await getPerceptionSessionTool.handler({});
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+```
+
+- [ ] **Step 6: Update `tests/unit/mcp/tools.test.ts`**
+
+Find `expect(TOOL_NAMES).toHaveLength(14);` and change to `toHaveLength(17);`.
+
+Add inside the existing describe block:
+```typescript
+  it('contains the three perception tools', () => {
+    expect(TOOL_NAMES).toContain('start_perception');
+    expect(TOOL_NAMES).toContain('stop_perception');
+    expect(TOOL_NAMES).toContain('get_perception_session');
+  });
+```
+
+- [ ] **Step 7: Run all unit + the existing smoke test**
+
+```bash
+pnpm exec vitest run --reporter=verbose tests/unit/ tests/integration/smoke.test.ts
+```
+Expected: previously-passing tests still pass; the updated `tools.test.ts` asserts 17 tools.
+
+- [ ] **Step 8: Typecheck**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/mcp/tools/perception.ts src/mcp/server.ts tests/unit/mcp/
+git commit -m "feat(mcp): start_perception / stop_perception / get_perception_session"
+```
+
+---
+
+## Task 9: Claude skill — `perception-session`
+
+**Files:**
+- Create: `skills/perception-session/SKILL.md`
+
+A Claude Code skill that wraps the perception MCP tools into a structured inspection workflow. Lives in the repo for version control; users symlink or copy to `~/.claude/skills/` to make it available in their Claude Code sessions.
+
+No automated tests for the skill — it's markdown content. We do verify the file exists and the frontmatter parses.
+
+- [ ] **Step 1: Create `skills/perception-session/SKILL.md`**
+
+```markdown
+---
+name: perception-session
+description: Use when investigating what UIPE's perception layer captures during a workflow. Wraps start_perception → drive action → inspect events + summary → stop into a structured session, then reports a markdown summary of which loops fired, anomalies triggered, and intent-loop classifications. Also use when the user says "what did perception see," "test the perception loops," or "show me anomalies for this workflow."
+---
+
+# perception-session
+
+You're using UIPE's perception layer to investigate what the system actually
+captures while a workflow runs on a page. This skill orchestrates the
+session: start perception, drive the workflow, inspect the timeline +
+summary, stop perception, and report a structured markdown summary.
+
+## When to use this
+
+- The user wants to validate that a specific UI change (count-up animation,
+  toast notification, modal mutation) is being captured by perception.
+- The user wants to debug "why didn't perception fire an anomaly here?"
+- The user wants a report of perception activity over a workflow they're
+  about to drive.
+
+## When NOT to use this
+
+- The user just wants to navigate or analyze a single page (use
+  `navigate` + `get_scene` directly).
+- The user is asking about UIPE's source code (use Read + grep).
+- The workflow has no expected perception activity to assert on.
+
+## How to use this
+
+1. **Confirm the workflow.** Ask the user (or restate from context) what
+   workflow you'll drive and what they expect perception to capture. Be
+   explicit about expected anomalies if any (e.g. "expect 1 anomaly of
+   reason mutation-outside-animation when the counter ticks up").
+
+2. **Start the session.** Call `start_perception`. This auto-starts watch
+   (keyframe capture) if not already running. Record the `startedAt`
+   timestamp.
+
+3. **Drive the workflow.** Use existing MCP tools (`navigate`, `act` with
+   click/scroll/type/wait, etc.) to execute the steps. Wait long enough
+   between steps for perception to process — give 500ms-1s of buffer after
+   each action.
+
+4. **(Optional) Peek mid-flight.** For long workflows, call
+   `get_perception_session` partway through to see running stats. Useful
+   if a loop appears stuck.
+
+5. **Stop the session.** Call `stop_perception`. This returns the final
+   summary as JSON. Do NOT stop watch — leave keyframe capture running
+   for other consumers.
+
+6. **Pull the relevant timeline events.** Call `get_timeline` filtered to
+   `perception-tick`, `perception-anomaly`, `perception-escalation`,
+   `perception-intent-result` with `since: <startedAt>`. This gives the
+   detailed event sequence to back up the summary.
+
+7. **Produce a report.** Generate markdown with these sections:
+   - **Session overview**: duration, tick counts per tier, achieved vs target cadence
+   - **Anomalies**: timestamps, reasons, target nodes, count by reason
+   - **Escalations**: from-tier → to-tier counts
+   - **Intent results**: VLM classifications per region
+   - **VLM cost**: best-effort dollar estimate from `vlmCalls`
+   - **Assertions** (if user stated expectations): ✅ or ❌ per expectation,
+     with the relevant timeline snippet if it failed
+
+Make the report scannable. Use tables for repeated rows (anomalies,
+intent results). Quote specific timeline events when explaining failures.
+
+## What perception can detect today (v1)
+
+- **Anomaly trigger**: `mutation-outside-animation`. Fires when DOM
+  mutations happen while no CSS animation is active. Catches things like
+  JS-driven count-up animations, IntersectionObserver-triggered state
+  updates, React re-renders that change text content.
+- **Escalation chain**: frame loop → semantic loop → intent loop. Frame
+  spots the anomaly, semantic checks if the affected nodes are
+  unclassified components, intent classifies new components via VLM.
+
+## What perception does NOT yet detect (v1 limitations)
+
+- CSS `transition` (not `Animation` API) — false negatives.
+- Animation deviation, new component signatures, optical-flow motion
+  triggers — deferred to v2.
+- Mutations on subtree A while an animation runs on subtree B — global
+  temporal gate suppresses these as false negatives.
+
+Be honest about these limits in the report when relevant.
+```
+
+- [ ] **Step 2: Verify the file parses**
+
+The skill is markdown with YAML frontmatter. No code to typecheck. Just confirm the file exists:
+
+```bash
+test -f skills/perception-session/SKILL.md && echo "ok"
+```
+
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/perception-session/SKILL.md
+git commit -m "feat(skill): perception-session — inspection workflow wrapper"
+```
+
+---
+
+## Task 10: Integration test — Playwright full-chain
+
+**Files:**
+- Create: `tests/integration/perception/fixtures/mutation-trigger.html`
+- Create: `tests/integration/perception/perception-e2e.test.ts`
+
+End-to-end test against real Chromium + a static HTML fixture with a deliberate "mutation outside animation" trigger.
+
+- [ ] **Step 1: Create the fixture**
+
+`tests/integration/perception/fixtures/mutation-trigger.html`:
+
+```html
+<!DOCTYPE html>
+<html>
+<head><title>Mutation Trigger</title>
+<style>
+  body { font-family: system-ui; padding: 24px; }
+  #target { display: block; width: 200px; height: 80px; padding: 16px; border: 1px solid #ccc; background: #eef; }
+  button { padding: 8px 16px; cursor: pointer; }
+</style>
+</head>
+<body>
+  <button id="trigger">Trigger mutation</button>
+  <div class="custom-card" id="target">
+    <span id="text">initial</span>
+  </div>
+  <script>
+    document.getElementById('trigger').addEventListener('click', () => {
+      // Pure JS mutation — no CSS animation.
+      setTimeout(() => {
+        document.getElementById('text').textContent = 'changed';
+      }, 50);
+    });
+  </script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Write the e2e test**
+
+`tests/integration/perception/perception-e2e.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { chromium, type Browser, type Page } from 'playwright';
+import { readFile, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { EventEmitter } from 'node:events';
+import { StructuralPipeline } from '../../../src/pipelines/structural/index.js';
+import { ComponentIndexStore } from '../../../src/pipelines/component-index/store.js';
+import { ClassificationQueue } from '../../../src/pipelines/component-index/queue.js';
+import { Matcher } from '../../../src/pipelines/component-index/matcher.js';
+import { Indexer } from '../../../src/pipelines/component-index/indexer.js';
+import { TemporalEventStream } from '../../../src/pipelines/temporal/event-stream.js';
+import { MutationCollector, AnimationCollector } from '../../../src/pipelines/temporal/collectors/index.js';
+import { PerceptionSession } from '../../../src/pipelines/perception/session.js';
+
+const FIXTURE = resolve(fileURLToPath(import.meta.url), '..', 'fixtures', 'mutation-trigger.html');
+
+class FakeFrameCapture extends EventEmitter {
+  start = vi.fn(async () => {});
+  stop = vi.fn(async () => {});
+  emitFakeKeyframe(timestamp: number) {
+    this.emit('keyframe', { frame: Buffer.from([0x89, 0x50]), timestamp });
+  }
+}
+
+describe('Perception loops — end-to-end (Playwright)', () => {
+  let browser: Browser;
+  let page: Page;
+  let tmp: string;
+
+  beforeAll(async () => { browser = await chromium.launch(); });
+  afterAll(async () => { await browser.close(); });
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'uipe-perception-e2e-'));
+    const html = await readFile(FIXTURE, 'utf8');
+    page = await browser.newPage({ viewport: { width: 800, height: 600 } });
+    await page.setContent(html, { waitUntil: 'load' });
+  });
+
+  afterEach(async () => {
+    await page.close();
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('full chain: mutation → frame anomaly → semantic escalation → intent VLM', async () => {
+    const stream = new TemporalEventStream();
+    const mutationCollector = new MutationCollector();
+    const animationCollector = new AnimationCollector();
+    await stream.attach(page, [mutationCollector, animationCollector]);
+
+    const structural = new StructuralPipeline();
+    const store = new ComponentIndexStore({ baseDir: tmp });
+    const queue = new ClassificationQueue();
+    const matcher = new Matcher({ store, queue });
+    const indexer = new Indexer({ matcher });
+
+    const stubVlm = vi.fn(async () => 'TestComponent');
+    const frameCapture = new FakeFrameCapture();
+    const session = new PerceptionSession({ eventStream: stream });
+    session.start(Date.now() - 1000, {  // start 1s in the past so warmup is past
+      page,
+      frameCapture: frameCapture as any,
+      indexer,
+      structuralPipeline: structural,
+      classifyByVlm: stubVlm,
+      getScreenshot: async () => page.screenshot({ type: 'png' }),
+    });
+
+    // Wait past the warmup window (500ms default)
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Click the button → after 50ms a text mutation fires (no CSS animation)
+    await page.click('#trigger');
+    await new Promise((r) => setTimeout(r, 300));
+
+    // Manually emit a frame keyframe (we use a fake frame capture)
+    frameCapture.emitFakeKeyframe(Date.now());
+    await new Promise((r) => setTimeout(r, 300));
+
+    // Stop perception
+    session.stop(Date.now());
+    const summary = session.getSummary();
+
+    expect(summary.anomalyCount).toBeGreaterThanOrEqual(1);
+    expect(summary.anomaliesByReason['mutation-outside-animation']).toBeGreaterThanOrEqual(1);
+    expect(summary.escalationCount).toBeGreaterThanOrEqual(1);
+    // Intent only fires if the semantic loop flagged a pending component.
+    // This depends on the fixture's text node being a recognized signature
+    // or not; we don't assert intent strictly here — just verify the chain.
+  }, 30_000);
+
+  it('does not fire anomaly when mutation happens during an active animation', async () => {
+    // Add an explicit CSS animation that's running when we trigger the mutation
+    await page.evaluate(() => {
+      const target = document.getElementById('target')!;
+      target.animate(
+        [{ opacity: 1 }, { opacity: 0.5 }, { opacity: 1 }],
+        { duration: 2000, iterations: 1 },
+      );
+    });
+
+    const stream = new TemporalEventStream();
+    const mutationCollector = new MutationCollector();
+    const animationCollector = new AnimationCollector();
+    await stream.attach(page, [mutationCollector, animationCollector]);
+
+    const structural = new StructuralPipeline();
+    const store = new ComponentIndexStore({ baseDir: tmp });
+    const queue = new ClassificationQueue();
+    const matcher = new Matcher({ store, queue });
+    const indexer = new Indexer({ matcher });
+
+    const stubVlm = vi.fn(async () => 'X');
+    const frameCapture = new FakeFrameCapture();
+    const session = new PerceptionSession({ eventStream: stream });
+    session.start(Date.now() - 1000, {
+      page,
+      frameCapture: frameCapture as any,
+      indexer,
+      structuralPipeline: structural,
+      classifyByVlm: stubVlm,
+      getScreenshot: async () => page.screenshot({ type: 'png' }),
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+    await page.click('#trigger');
+    await new Promise((r) => setTimeout(r, 200));
+
+    frameCapture.emitFakeKeyframe(Date.now());
+    await new Promise((r) => setTimeout(r, 200));
+
+    session.stop(Date.now());
+    const summary = session.getSummary();
+    expect(summary.anomalyCount).toBe(0);
+  }, 30_000);
+});
+```
+
+- [ ] **Step 3: Run the integration test (scoped)**
+
+```bash
+pnpm exec vitest run --reporter=verbose tests/integration/perception/
+```
+Expected: 2 passing within ~10-30s. If Playwright complains about missing Chromium, run `pnpm exec playwright install chromium` once.
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/integration/perception/
+git commit -m "test(perception): Playwright e2e — full anomaly chain + animation-suppression case"
+```
+
+---
+
+## Task 11: Docs update
+
+**Files:**
+- Modify: `/Users/dirkknibbe/uipe/docs/autopilot-program-roadmap.md` (workspace root, NOT in git — per CLAUDE.md carry-forward #7)
+- Modify: `/Users/dirkknibbe/uipe/docs/architecture.md` (workspace root)
+
+Per the spec, the workspace-root docs are direct file writes that aren't committed via git. The task's deliverable is the on-disk edit.
+
+- [ ] **Step 1: Update `/Users/dirkknibbe/uipe/docs/autopilot-program-roadmap.md`**
+
+Find sub-project #7 (it will say `▶ #7 — Hierarchical loops at fixed rates`). Replace the entry with:
+
+```markdown
+### ✅ #7 — Hierarchical loops at fixed rates (+ Anomaly-triggered attention #8)
+
+`PerceptionSession` orchestrator with three autonomous loops at distinct cadences: frame (~16ms, tied to keyframe emission), semantic (~200ms), and intent (~1s). Rate-bounded, event-driven — loops are idle by default and wake on heartbeat-with-pending-work or escalation from a faster loop. v1 ships with one anomaly trigger: `mutation-outside-animation`. New event types (`perception-tick`, `perception-anomaly`, `perception-escalation`, `perception-intent-result`) flow through `TemporalEventStream`. Three new MCP tools (`start_perception`, `stop_perception`, `get_perception_session`) + a `perception-session` Claude skill for inspection sessions. Merged 2026-05-DD (commit `<TBD-fill-in-after-merge>`). **Depends on:** #2 (✓), #1 (✓), #3 (✓), #4 (✓).
+```
+
+Find sub-project #8 (`◌ #8 — Anomaly-triggered attention`). Replace the entry with:
+
+```markdown
+### ✅ #8 — Anomaly-triggered attention (merged into #7)
+
+Shipped jointly with #7 (Hierarchical loops). The merge made sense because the rate-tiered loop infrastructure has no useful consumer without anomaly triggers, and the anomaly triggers' value depends on the loop hierarchy being in place. v1 anomaly: `mutation-outside-animation`. Additional triggers (animation deviation, new component signature, optical-flow motion) deferred to v2. See #7 entry for shipping details.
+```
+
+Update the "Recommended next pick" section. Find it (it likely points at #7 today) and replace with:
+
+```markdown
+## Recommended next pick (after #1, #3, #4, #7+#8 shipped)
+
+**Storybook seeding adapter for #4** OR **SLAM for SPA routes (#5)**.
+
+- The Storybook adapter is the obvious follow-up to #4 — it'd significantly reduce cold-start VLM cost on apps that publish a Storybook. The design question (Storybook entries vs first-traversal precedence) is tractable; implementation effort is modest.
+- #5 (SLAM for SPA routes) is the next big architectural piece. Both prerequisites (#2 timeline, #4 component signatures) are satisfied. Builds the agent's spatial model: routes + transitions + components reachable from each. Multi-week scope.
+
+Storybook is the smaller, faster ship; #5 is the more architecturally consequential. Either is reasonable.
+```
+
+- [ ] **Step 2: Update `/Users/dirkknibbe/uipe/docs/architecture.md`**
+
+Find the "Current implementation" table. Find the row for #7 (`Hierarchical loops at fixed rates`) and replace the rightmost column with:
+
+```
+**Shipped** (PR `<TBD>`, merged 2026-05-DD, branch `feat/perception-loops`). `PerceptionSession` orchestrator at `src/pipelines/perception/` runs three autonomous loops at distinct cadences. Frame loop subscribes to `FrameCapture` keyframes; semantic + intent are rate-bounded and event-driven. v1 anomaly trigger: `mutation-outside-animation`. New `perception-*` event types on `TemporalEventStream`; three new MCP tools (`start_perception`, `stop_perception`, `get_perception_session`). A `perception-session` Claude skill orchestrates inspection workflows. Follow-ups: CSS `transition` detection (separate collector), spatial gating (subtree-aware anomaly suppression), additional anomaly triggers (animation deviation, new component signature, optical-flow motion).
+```
+
+Find the row for #8 (`Anomaly-triggered attention`) and replace with:
+
+```
+**Shipped** (jointly with #7, see above). v1 trigger: `mutation-outside-animation`. Escalation chain: frame loop spots anomaly → semantic loop checks the affected nodes via component-index → intent loop classifies unclassified components via VLM. Additional triggers deferred to v2.
+```
+
+- [ ] **Step 3: Verify nothing else broke**
+
+```bash
+pnpm exec tsc --noEmit && pnpm exec vitest run --reporter=dot tests/unit/
+```
+Expected: no test changes — docs-only edits live outside the repo.
+
+- [ ] **Step 4: No git commit for Task 11**
+
+The workspace-root docs are not in a git repo (per CLAUDE.md carry-forward #7). The deliverable is the on-disk edit; the post-merge note about the commit hash gets backfilled later.
+
+---
+
+## Self-review verification (run before declaring complete)
+
+- [ ] **Spec coverage:** every spec section maps to a task:
+  - "Architecture" + ASCII diagram → Tasks 4-7 (loops + session wiring)
+  - "Data shapes" → Task 1
+  - "v1 anomaly trigger" → Task 2 + Task 4 (FrameLoop calls it)
+  - "MCP tool surface" → Task 8
+  - "Claude skill" → Task 9
+  - "Edge cases" table → covered across Task 4 (debounce, animation gate), Task 6 (backpressure, screenshot null), Task 7 (page nav/close), Task 8 (already-running, missing session)
+  - "Testing" → Tasks 1-8 (unit) + Task 10 (integration)
+  - "Implementation phasing" → Tasks 1-11
+  - "Docs + roadmap update" → Task 11
+
+- [ ] **Naming consistency** — verify these names match identically across tasks:
+  - Classes: `PerceptionSession`, `FrameLoop`, `SemanticLoop`, `IntentLoop`
+  - Functions: `detectMutationOutsideAnimation`
+  - Tool factories: `makeStartPerceptionTool`, `makeStopPerceptionTool`, `makeGetPerceptionSessionTool`
+  - Types: `PerceptionTier`, `AnomalyReason`, `PerceptionSessionSummary`, `SessionStartDeps`, `DetectInput`, `DetectConfig`, `DetectResult`
+  - Tool names: `'start_perception'`, `'stop_perception'`, `'get_perception_session'`
+  - Event types: `'perception-tick'`, `'perception-anomaly'`, `'perception-escalation'`, `'perception-intent-result'`
+
+- [ ] **Run the full unit suite one final time:**
+
+```bash
+pnpm exec vitest run --reporter=dot tests/unit/
+```
+Expected: ≥ ~50 new unit tests across the 7 perception unit-test files + 1 MCP test file, plus all previously-passing tests still pass.
+
+---
+
+## Definition of done
+
+After Task 11 completes:
+
+- [ ] All perception unit tests pass: `pnpm exec vitest run tests/unit/pipelines/perception/ tests/unit/mcp/perception.test.ts`
+- [ ] Previously-passing tests still pass: `pnpm exec vitest run tests/unit/`
+- [ ] Integration test passes: `pnpm exec vitest run tests/integration/perception/`
+- [ ] Typecheck clean: `pnpm exec tsc --noEmit`
+- [ ] Lint clean: `pnpm exec eslint src tests --ext .ts`
+- [ ] `start_perception` / `stop_perception` / `get_perception_session` are listed in `TOOL_NAMES` and registered on the MCP server
+- [ ] `perception-tick`, `perception-anomaly`, `perception-escalation`, `perception-intent-result` appear on the timeline when running the MCP server against a page that triggers the v1 anomaly
+- [ ] `docs/autopilot-program-roadmap.md` (workspace-root) shows #7 + #8 as ✅
+- [ ] `docs/architecture.md` (workspace-root) "Current implementation" table reflects both as Shipped
+- [ ] `skills/perception-session/SKILL.md` exists in the repo
+
+## Out of scope (deferred to follow-up tickets/PRs)
+
+These are explicitly NOT part of this plan:
+
+- Additional anomaly triggers (`new-component-signature`, `animation-deviation-high`, `optical-flow-motion-above-threshold-while-no-animation`) — each is a single-file detector + a one-line addition to the `AnomalyReason` union when picked up
+- CSS `transition` tracking via a v2 `TransitionCollector`
+- Spatial gating (per-animation target-ancestor tracking + spatial-overlap check)
+- Configurable thresholds via runtime config (`PerceptionConfig` exposed via MCP)
+- Persisted session summaries across server restarts (`~/.uipe/perception/sessions/`)
+- Multi-page parallel perception
+- VLM cost budgeting / rate limiting beyond best-effort observability
+- Anomaly persistence beyond the timeline ring buffer
+- The skill's "expected anomalies" assertion grammar (turning the skill into a real test framework)
+- Semantic loop performance: today it re-runs the *full* structural pipeline + indexer on each wake; a v2 optimization would scope to changed subtrees only
+- Resolving real bboxes from mutation payloads in the frame loop — today we emit nodeIds with `{0,0,0,0}` placeholder bboxes; the semantic loop resolves real bboxes from the structural pipeline. If frame-level bboxes become useful, the `MutationCollector` would need to capture bbox snapshots at mutation time.

--- a/docs/superpowers/specs/2026-05-17-perception-loops-design.md
+++ b/docs/superpowers/specs/2026-05-17-perception-loops-design.md
@@ -1,0 +1,383 @@
+# Perception Loops — Design
+
+**Date:** 2026-05-17
+**Status:** Draft — pending user review
+**Roadmap entries:** [`docs/autopilot-program-roadmap.md`](../../autopilot-program-roadmap.md) — sub-projects #7 (Hierarchical loops at fixed rates) and #8 (Anomaly-triggered attention), merged into one v1 sub-project
+**Architecture source:** [`docs/architecture.md`](../../architecture.md) §"Techniques to borrow, ranked by impact" #7 (Hierarchical loops) + #8 (Anomaly-triggered attention)
+
+## Goal
+
+Formalize UIPE's perception layer as three rate-bounded, event-driven loops at distinct cadences — frame (~16ms, tied to keyframe emission), semantic (~200ms), and intent (~1s). Loops are idle by default and wake on either a heartbeat-with-pending-work or an escalation from a faster loop. Anomaly triggers connect the tiers: when a faster loop spots something unexpected, it escalates work to the slower, more expensive loop. v1 ships with one trigger — **DOM mutation outside an active CSS animation** — proving the full escalation chain on a concrete case.
+
+The autopilot analogy: in Tesla / Waymo perception, the fast loop (sensor fusion at ~60Hz) is always running, the slower loops (motion planning at ~10Hz, route planning at ~1Hz) wake when needed. UIPE's equivalent: frame loop subscribes to keyframes, semantic loop wakes on frame-detected anomalies, intent loop wakes when the semantic loop flags an unclassified component for VLM treatment.
+
+## Primary consumer
+
+**The agent observing what UIPE perceives, via the timeline.** New `perception-*` event types flow through `TemporalEventStream` so an agent calling `get_timeline` sees every tick, anomaly, escalation, and intent-result. The agent's existing model (poll for events, reason about state) doesn't change; the timeline just carries richer information.
+
+Secondary consumer: **the developer using the `perception-session` Claude skill** to debug "what is perception actually seeing on this page during this workflow?" The skill is an inspection layer on top of the MCP tool surface, not a CI gate.
+
+## Non-goals (v1)
+
+- **Additional anomaly triggers** beyond `mutation-outside-animation`. The candidates discussed in brainstorming (animation deviation > 0.5, new component signature, optical-flow motion above threshold while no animation is tracked) are deferred. Each is a single-file detector + a one-line addition to the `AnomalyReason` union when picked up in v2.
+- **CSS `transition` tracking.** `AnimationCollector` tracks the Web Animations API (`Animation` objects), not CSS `transition`. A transition-triggered DOM change while no `Animation` is in flight = false anomaly. A v2 `TransitionCollector` would close this gap.
+- **Spatial gating.** Mutations on subtree A while an animation runs on subtree B are suppressed by the global temporal gate. Per-animation target-ancestor tracking + spatial-overlap is v2.
+- **Configurable thresholds via runtime config.** `lookbackMs`, `warmupMs`, `coalesceMs`, semantic-loop cadence, intent-loop cadence are constants in v1. Tuned in source, not via MCP.
+- **Persisted session summaries across server restarts.** Summaries live in-memory until next `start_perception`. Disk persistence is v2.
+- **Multi-page parallel perception.** Single session per MCP server. If `BrowserRuntime` ever supports parallel tabs, a session-per-page model is needed.
+- **VLM cost budgeting / rate limiting.** `vlmCalls.estimatedDollars` is best-effort observability; no quota, no kill-switch.
+- **Anomaly persistence.** Anomalies live in `TemporalEventStream`'s ring buffer (lossy by design). Long-session preservation would need a v2 `AnomalyStore`.
+- **The skill's "expected anomalies" assertion grammar.** v1 skill report is descriptive. A v2 assertion grammar (`"workflow X must produce 1 anomaly of reason Y"`) would make the skill a real test framework.
+
+## Architecture
+
+```
+   FrameCapture (existing)
+        │  keyframe event
+        ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  FrameLoop                                                           │
+│  src/pipelines/perception/frame-loop.ts                              │
+│                                                                       │
+│  on keyframe:                                                         │
+│    emit perception-tick { tier: 'frame', cause: 'keyframe' }          │
+│    detector = detectMutationOutsideAnimation({                        │
+│      recentMutations,    // ring buffer trimmed to lookbackMs         │
+│      activeAnimations,   // Set<animId> from anim-start/-end events   │
+│      nowMs, sessionStartMs,                                            │
+│    })                                                                 │
+│    if detector returned a result:                                     │
+│      emit perception-anomaly { tier, reason, detail }                 │
+│      emit perception-escalation { from: 'frame', to: 'semantic' }     │
+│      EventEmitter.emit('escalate', { from: 'frame', regions })        │
+└─────────────────────────────┬────────────────────────────────────────┘
+                              │ escalate event
+                              ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  SemanticLoop                                                        │
+│  src/pipelines/perception/semantic-loop.ts                           │
+│                                                                       │
+│  wake conditions:                                                     │
+│    - escalation from frame loop                                       │
+│    - heartbeat (max cadence ~200ms) if work accumulated                │
+│                                                                       │
+│  on wake:                                                             │
+│    emit perception-tick { tier: 'semantic', cause }                   │
+│    for each flagged region:                                           │
+│      extract structural state of mutation target subtree              │
+│      run component-index match (uses #4's indexer)                    │
+│      if any node has component.status === 'pending':                  │
+│        EventEmitter.emit('escalate', { from: 'semantic', regions })   │
+│        emit perception-escalation { from: 'semantic', to: 'intent' }  │
+└─────────────────────────────┬────────────────────────────────────────┘
+                              │ escalate event
+                              ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  IntentLoop                                                          │
+│  src/pipelines/perception/intent-loop.ts                             │
+│                                                                       │
+│  wake conditions:                                                     │
+│    - escalation from semantic loop (only)                             │
+│    - target cadence ~1s, but never fires on heartbeat alone           │
+│                                                                       │
+│  on wake:                                                             │
+│    emit perception-tick { tier: 'intent', cause: 'escalation' }       │
+│    for each flagged region:                                           │
+│      crop screenshot to region.bbox via sharp                         │
+│      result = await classifyByVlm({ html: '', screenshotCrop })       │
+│      emit perception-intent-result { region, classification, ... }    │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+**Module boundaries:**
+- `session.ts` — `PerceptionSession` orchestrator. Owns lifecycle (`start(page)`, `stop()`, `getSummary()`). Instantiates the three loops + the in-process `EventEmitter` that wires them. Holds the in-memory summary state.
+- `frame-loop.ts` — `FrameLoop` class. Maintains `activeAnimations: Set<string>` (from anim-start/-end events) and `recentMutations` ring buffer. Subscribes to `FrameCapture` keyframes. Calls the pure detector on each keyframe.
+- `semantic-loop.ts` — `SemanticLoop` class. Owns its target-cadence timer (idle gating). On wake: re-extracts the changed subtree's structural state, hands to the existing component-`Indexer` (from #4).
+- `intent-loop.ts` — `IntentLoop` class. Pure event-driven (no heartbeat). Wraps `classifyByVlm` (from #4) + sharp crop.
+- `anomaly/mutation-outside-animation.ts` — pure detector function. No state, no I/O.
+- `types.ts` — `PerceptionSessionSummary`, `PerceptionTier`, runtime helpers. Event payload types live in `temporal/collectors/types.ts` alongside the rest of the timeline types.
+
+**Pipeline integration point:** Perception is a top-level subsystem instantiated in `src/mcp/server.ts`. The frame loop subscribes to `FrameCapture`'s `keyframe` events and to `TemporalEventStream`'s anim-start/-end events. The semantic loop calls into the existing `Indexer` from sub-project #4. The intent loop calls `classifyByVlm` from #4. No mutation of existing pipeline outputs — perception layers on top.
+
+## Data shapes
+
+### Event payload types
+
+```typescript
+// In src/pipelines/temporal/collectors/types.ts (alongside existing payloads)
+
+export type PerceptionTier = 'frame' | 'semantic' | 'intent';
+export type AnomalyReason = 'mutation-outside-animation';   // v1: single trigger
+
+export interface PerceptionTickPayload {
+  tier: PerceptionTier;
+  cause: 'keyframe' | 'heartbeat' | 'escalation' | 'navigation-reset';
+}
+
+export interface PerceptionAnomalyPayload {
+  tier: PerceptionTier;              // which loop detected it
+  reason: AnomalyReason;
+  detail: {
+    mutationCount: number;           // mutations in the coalesced burst
+    targetNodeIds: string[];         // affected DOM nodes (deduped)
+  };
+}
+
+export interface PerceptionEscalationPayload {
+  from: PerceptionTier;
+  to: PerceptionTier;
+  reason: AnomalyReason;
+  regions: Array<{
+    nodeId: string;
+    bbox: { x: number; y: number; w: number; h: number };
+  }>;
+}
+
+export interface PerceptionIntentResultPayload {
+  region: { nodeId: string; bbox: { x: number; y: number; w: number; h: number } };
+  classification: string;             // e.g. "AnimatedCounter", "ToastNotification", "Unknown"
+  classificationSource: 'vlm';
+  durationMs: number;                 // VLM round-trip time
+}
+```
+
+### EventType + PayloadFor extensions
+
+```typescript
+export type EventType =
+  | 'input' | 'mutation' | 'network-request' | 'network-response'
+  | 'animation-start' | 'animation-end' | 'animation-prediction'
+  | 'phash-change'
+  | 'optical-flow-raw' | 'optical-flow-region' | 'optical-flow-motion'
+  | 'perception-tick' | 'perception-anomaly' | 'perception-escalation' | 'perception-intent-result';
+
+export type PayloadFor<T extends EventType> =
+  // ... existing rows ...
+  T extends 'perception-tick'           ? PerceptionTickPayload :
+  T extends 'perception-anomaly'        ? PerceptionAnomalyPayload :
+  T extends 'perception-escalation'     ? PerceptionEscalationPayload :
+  T extends 'perception-intent-result'  ? PerceptionIntentResultPayload :
+  never;
+```
+
+### Session summary
+
+```typescript
+// In src/pipelines/perception/types.ts
+
+export interface PerceptionSessionSummary {
+  startedAt: number;                       // stream-relative ms at session start
+  durationMs: number;                      // wall-clock elapsed
+  tickCounts: Record<PerceptionTier, number>;
+  averageCadenceMs: Record<PerceptionTier, number | null>;  // null if loop never ticked
+  targetCadenceMs: Record<PerceptionTier, number>;          // {frame: keyframe-bound, semantic: 200, intent: 1000}
+  anomalyCount: number;
+  anomaliesByReason: Record<AnomalyReason, number>;
+  escalationCount: number;
+  intentResultCount: number;
+  vlmCalls: { count: number; estimatedDollars?: number };   // best-effort cost surface
+}
+```
+
+## v1 anomaly trigger — `mutation-outside-animation`
+
+Pure function, called by `FrameLoop` on each keyframe. The loop owns state (active-animation set, recent-mutation buffer); the detector is data-in / data-out.
+
+```typescript
+// src/pipelines/perception/anomaly/mutation-outside-animation.ts
+
+export interface DetectInput {
+  recentMutations: TimelineEvent<'mutation'>[];   // ring-buffer-trimmed to lookbackMs
+  activeAnimations: Set<string>;                  // animationIds currently running
+  nowMs: number;
+  sessionStartMs: number;
+}
+
+export interface DetectConfig {
+  lookbackMs: number;        // default 200 — window of "recent" mutations
+  coalesceWindowMs: number;  // default 100 — group bursts into one anomaly
+  warmupMs: number;          // default 500 — suppress mutations right after session start
+}
+
+export type DetectResult =
+  | null
+  | { mutationCount: number; targetNodeIds: string[] };
+
+export function detectMutationOutsideAnimation(
+  input: DetectInput,
+  config?: DetectConfig,
+): DetectResult;
+```
+
+**Decision logic (in order):**
+
+1. **Warm-up gate.** If `nowMs - sessionStartMs < warmupMs` → return null. Suppresses page-load + hydration mutation bursts.
+2. **Active-animation gate.** If `activeAnimations.size > 0` → return null. Any CSS animation in flight = mutations are "expected."
+3. **Coalesce.** Group `recentMutations` into bursts (gaps ≤ `coalesceWindowMs` belong to the same burst). Take only the latest burst (the one whose latest timestamp is closest to `nowMs`). Deduplicate target node IDs.
+4. **Empty-result short-circuit.** If burst is empty → return null.
+5. **Emit.** Return `{ mutationCount: burst.length, targetNodeIds: [...uniqueIds] }`.
+
+**State managed by `FrameLoop`:**
+- `activeAnimations: Set<string>` — added on `animation-start`, removed on `animation-end`.
+- `recentMutations: TimelineEvent<'mutation'>[]` — append on `mutation` events, trim to `lookbackMs` on each keyframe tick.
+- `lastAnomalyEmittedAt: number` — debounce so back-to-back keyframes don't re-fire the same anomaly. Suppress if within `coalesceWindowMs` of last emit.
+
+**Why this catches the Garner count-up case** (validated during brainstorm against `https://garnerhcre-rebuild.vercel.app/`): IntersectionObserver fires → React `setState` schedules re-render → `<span>$0M+</span>` text content changes to `<span>$5M+</span>`. `MutationCollector` captures the mutation. No CSS animation was started (pure JS counter). `activeAnimations` is empty. Past the 500ms warmup. Result: one anomaly per coalesced burst → semantic loop wakes → checks the component-index → finds the `<span>` matches a known signature → suppresses VLM (already classified). Cost: one frame-tick + one semantic-tick. No VLM call. Visible in the timeline as a `perception-anomaly` event.
+
+## MCP tool surface
+
+Three new tools registered in `src/mcp/server.ts`:
+
+**`start_perception`** — Begin a perception session.
+
+```typescript
+inputSchema: z.object({})
+```
+
+Behavior:
+1. If no `FrameCapture` is running, auto-start `watch` (perception requires keyframes).
+2. Instantiate `PerceptionSession`, call `start(page)`.
+3. Store as `currentSession` on the server.
+4. Return `{ status: 'started', startedAt: <stream-relative-ms> }` or `{ status: 'already-running', startedAt: <existing> }`.
+
+Errors: no page attached → `"Call navigate first."`
+
+**`stop_perception`** — End the current session, return summary.
+
+```typescript
+inputSchema: z.object({})
+```
+
+Behavior:
+1. Call `currentSession.stop()` (unsubscribes loops; clears timers).
+2. Capture `currentSession.getSummary()` into `lastSummary`.
+3. Clear `currentSession`. Do NOT auto-stop `watch` — keyframe capture stays alive for non-perception consumers.
+4. Return the summary as JSON.
+
+Errors: no active session → returns `lastSummary` if any, else `{ error: 'No session active and no prior summary' }`.
+
+**`get_perception_session`** — Read-only snapshot.
+
+```typescript
+inputSchema: z.object({})
+```
+
+Behavior: returns `currentSession.getSummary()` if running, else `lastSummary` if any, else `{ error: 'No session active and no prior summary' }`. Useful for the skill to peek mid-flight.
+
+The existing `get_timeline` tool exposes all `perception-*` events via the standard timeline filter (`types: ['perception-tick', 'perception-anomaly', ...]`).
+
+## Claude skill — `perception-session`
+
+Lives at `ui-perception-engine/skills/perception-session/SKILL.md`. Invoked via Claude Code's `Skill` tool with a workflow description.
+
+```yaml
+---
+name: perception-session
+description: |
+  Use when investigating what UIPE's perception layer captures during a workflow.
+  Wraps start_perception → drive action → inspect events + summary → stop into
+  a structured session, then reports a markdown summary of which loops fired,
+  anomalies triggered, and intent-loop classifications.
+---
+```
+
+**Skill body instructions:**
+1. Accept a workflow description from the user.
+2. Call `start_perception` (auto-starts watch).
+3. Execute the workflow via existing `navigate` / `act` MCP tools.
+4. Optionally call `get_perception_session` mid-flight for long workflows.
+5. After the workflow completes, call `stop_perception` to get the final summary.
+6. Pull recent `perception-*` events from `get_timeline`.
+7. Produce a markdown report containing:
+   - Tick counts + actual cadences vs targets (per tier)
+   - Anomalies fired (timestamps + reasons + target nodes)
+   - Escalations (from-tier → to-tier counts)
+   - Intent-loop results (region classifications)
+   - VLM cost estimate (best-effort)
+   - Optional pass/fail vs user-stated expectations
+
+The skill encodes the inspection *workflow*; the underlying MCP tools remain composable for agents that prefer raw access.
+
+## Edge cases
+
+| Case | Behavior |
+|---|---|
+| `start_perception` called twice without `stop_perception` between | Return `{ status: 'already-running', startedAt: <existing> }`. Do NOT restart — silently resetting counts would mislead the caller. |
+| Page navigation during a session | `PerceptionSession` listens on `page.on('framenavigated', ...)`. On nav: emit `perception-tick { tier: 'frame', cause: 'navigation-reset' }`, clear `activeAnimations` + `recentMutations`, reset `sessionStartMs` to the new nav time (re-applies warmup). Session stays alive across navigations. |
+| Page closed (tab killed) mid-session | `page.on('close')` fires. Auto-stop the session; preserve the summary in `lastSummary` until next `start_perception`. |
+| `FrameCapture` not running mid-session (`watch` stopped externally) | Frame loop goes dormant (no keyframes = no ticks). Semantic + intent still wake via heartbeat / queued escalations. Summary surfaces `tickCounts.frame = 0` so the skill can flag it. |
+| VLM call fails (network error, missing API key) | `classifyByVlm` (from #4) returns `'Unknown'` rather than throwing. `vlmCalls.count` still increments; the intent-result emits with `classification: 'Unknown'`. Anomaly + escalation chains are unaffected. |
+| Coalesce-window miss (two bursts just outside the coalesce window) | Two anomalies fire instead of one. Acceptable in v1 — both timestamps land on the timeline; the skill's report shows both. Tune `coalesceWindowMs` if real-world false-doubles become common. |
+| Intent loop backpressure (escalations arrive faster than VLM responds) | `IntentLoop` maintains an internal pending queue (mirrors #4's `ClassificationQueue`). If pending > 10, drop oldest with a logger warning. No timeline event for drops (would be noise). |
+| Mutations on subtree A while CSS animation runs on subtree B | Suppressed by the global temporal gate. False negative. Documented in non-goals; spatial gating is v2. |
+| Mutation burst within the warmup window | Suppressed. False negative on initial workflow actions. Skill workflows should call `start_perception` *before* the first interaction to give warmup room. |
+| Heartbeat fires on a loop with no pending work | `perception-tick { cause: 'heartbeat' }` still emits — useful for the skill to verify the loop is alive. Cheap (single timeline event). |
+| Skill workflow runs longer than expected, never calls `stop_perception` | Session lingers as a zombie until manually stopped or page closed. Document as a known limit. |
+| Concurrent overlapping `start_perception` calls (rare but possible across awaits) | First call wins; second returns `already-running`. Same as the duplicate case. |
+
+## Testing
+
+### Pure unit tests in `tests/unit/pipelines/perception/`
+
+| File | Coverage |
+|---|---|
+| `anomaly/mutation-outside-animation.test.ts` | Warmup gate suppresses; active-animation gate suppresses; coalesce groups bursts ≤ `coalesceWindowMs`; dedupes target node IDs; empty input returns null; latest-burst-only selection. |
+| `frame-loop.test.ts` | On simulated keyframe → emits `perception-tick { tier: 'frame', cause: 'keyframe' }`. Animation-start/-end events update `activeAnimations`. Mutation events accumulate; ring buffer trims past `lookbackMs`. Detector return triggers anomaly + escalation events. Debounce suppresses back-to-back identical anomalies. |
+| `semantic-loop.test.ts` | Rate-bounded: two escalations within 50ms produce one tick (cadence honored). Heartbeat tick fires only when work pending. Calls component-`Indexer` on flagged regions. Escalates to intent when `component.status === 'pending'`. |
+| `intent-loop.test.ts` | Only fires on escalation, never on heartbeat. Calls mocked VLM classifier per region. Emits `perception-intent-result`. Backpressure: 11th pending escalation triggers oldest-drop. |
+| `session.test.ts` | `start(page)` wires all three loops + the EventEmitter. `stop()` unsubscribes cleanly (no zombie timers). `getSummary()` returns correct aggregate counts. Navigation event resets `sessionStartMs`. Page-close event auto-stops. |
+
+### Integration test in `tests/integration/perception/perception-e2e.test.ts`
+
+Playwright + a static HTML fixture with a deliberate "mutation outside animation" trigger:
+
+1. `page.setContent()` with a fixture: a button that, on click, triggers `setTimeout(() => el.textContent = 'changed', 100)` — pure JS, no CSS animation.
+2. `start_perception` (the test calls this via the server's tool handler directly, not via MCP — same pattern as #3's integration test).
+3. `page.click('button')`.
+4. Wait 500ms — enough for the mutation, frame tick, semantic tick, intent tick to all fire.
+5. `stop_perception` → get the summary.
+6. Assert: summary has exactly 1 anomaly of reason `mutation-outside-animation`, exactly 1 `frame→semantic` escalation, ≥ 1 `semantic→intent` escalation if the mutated element produces a `pending` component (configure the fixture so it does), mocked VLM called exactly once.
+
+VLM is mocked with a deterministic stub (returns `'TestComponent'`). Real-browser, real timing, no flakiness because the mutation timing is wall-clock-deterministic.
+
+### Performance budget
+
+- `FrameLoop.onKeyframe()` should complete in < 1ms — pure-TS detector + small ring-buffer ops.
+- `SemanticLoop.onWake()` cost is dominated by `Indexer.run()`, already characterized in #4 (< 50ms for typical pages).
+- `IntentLoop` cost is dominated by VLM round-trip (~500ms-2s; uncontrolled).
+
+## Implementation phasing (rough — full task breakdown in subsequent plan)
+
+1. Event-type union + payload types (`temporal/collectors/types.ts` extension + type tests)
+2. Pure detector: `anomaly/mutation-outside-animation.ts`
+3. `PerceptionSession` skeleton: lifecycle, summary stub, no loops yet
+4. `FrameLoop`: subscribes to keyframes + animation events, runs detector, emits events
+5. `SemanticLoop`: cadence timer, escalation queue, calls Indexer
+6. `IntentLoop`: escalation-driven, VLM call, backpressure
+7. `EventEmitter` wiring in `PerceptionSession`
+8. MCP tools (`start_perception`, `stop_perception`, `get_perception_session`) + server wiring
+9. `perception-session` Claude skill (`skills/perception-session/SKILL.md`)
+10. Integration test (Playwright + fixture)
+11. Docs + roadmap update (flip #7 + #8 to ✅, link to PR)
+
+Likely ~12-14 tasks in the implementation plan.
+
+## Open questions / follow-ups
+
+- **Coalesce-window calibration.** 100ms is a guess. Real-world testing on dynamic pages (SPAs with frequent re-renders) will tell us if it's too tight (false doubles) or too loose (lumping unrelated actions). Cheap to tune in source.
+- **Semantic-loop heartbeat cadence.** 200ms targets ~5Hz. If the loop's actual work (DOM re-extraction on subtree) is slow on heavy pages, we may need a longer heartbeat or pre-filter mutations.
+- **Intent-loop drop policy.** Oldest-first is the obvious default but "highest-priority-first" (e.g., based on bbox size) might be smarter once we have more anomaly reasons. Defer to v2 calibration.
+- **Skill assertion grammar.** Today's skill report is descriptive. A v2 assertion grammar (the skill takes "expected: 1 anomaly of reason mutation-outside-animation") would close the loop on "perception tests" being real tests, not just inspections.
+- **OmniParser tier integration.** If the semantic loop's component-extract becomes the bottleneck, OmniParser's region detection could feed into it as a tier-A pre-filter (same role OmniParser plays in `VisualPipeline.detectElements`). Out of scope for v1.
+
+## References
+
+- [`docs/architecture.md`](../../architecture.md) §"Hierarchical loops at fixed rates" + §"Anomaly-triggered attention" — canonical autopilot analogy
+- [`docs/autopilot-program-roadmap.md`](../../autopilot-program-roadmap.md) sub-projects #7 and #8 (merged here)
+- [`src/pipelines/temporal/event-stream.ts`](../../../src/pipelines/temporal/event-stream.ts) — existing timeline; perception events flow through it
+- [`src/pipelines/temporal/collectors/animation.ts`](../../../src/pipelines/temporal/collectors/animation.ts) — source of `animation-start`/`-end` events that feed `activeAnimations`
+- [`src/pipelines/temporal/collectors/mutation.ts`](../../../src/pipelines/temporal/collectors/mutation.ts) — source of mutation events the detector consumes
+- [`src/pipelines/component-index/indexer.ts`](../../../src/pipelines/component-index/indexer.ts) — sub-project #4; called by `SemanticLoop`
+- [`src/pipelines/component-index/vlm-classifier.ts`](../../../src/pipelines/component-index/vlm-classifier.ts) — sub-project #4; called by `IntentLoop`
+- [`docs/superpowers/specs/2026-05-12-component-index-design.md`](2026-05-12-component-index-design.md) — sub-project #4 spec, reference for spec/plan style
+- [`docs/superpowers/specs/2026-05-11-animation-predictive-verification-design.md`](2026-05-11-animation-predictive-verification-design.md) — sub-project #3 spec, reference for the pure-helpers + orchestrator pattern this design follows

--- a/skills/perception-session/SKILL.md
+++ b/skills/perception-session/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: perception-session
+description: Use when investigating what UIPE's perception layer captures during a workflow. Wraps start_perception → drive action → inspect events + summary → stop into a structured session, then reports a markdown summary of which loops fired, anomalies triggered, and intent-loop classifications. Also use when the user says "what did perception see," "test the perception loops," or "show me anomalies for this workflow."
+---
+
+# perception-session
+
+You're using UIPE's perception layer to investigate what the system actually
+captures while a workflow runs on a page. This skill orchestrates the
+session: start perception, drive the workflow, inspect the timeline +
+summary, stop perception, and report a structured markdown summary.
+
+## When to use this
+
+- The user wants to validate that a specific UI change (count-up animation,
+  toast notification, modal mutation) is being captured by perception.
+- The user wants to debug "why didn't perception fire an anomaly here?"
+- The user wants a report of perception activity over a workflow they're
+  about to drive.
+
+## When NOT to use this
+
+- The user just wants to navigate or analyze a single page (use
+  `navigate` + `get_scene` directly).
+- The user is asking about UIPE's source code (use Read + grep).
+- The workflow has no expected perception activity to assert on.
+
+## How to use this
+
+1. **Confirm the workflow.** Ask the user (or restate from context) what
+   workflow you'll drive and what they expect perception to capture. Be
+   explicit about expected anomalies if any (e.g. "expect 1 anomaly of
+   reason mutation-outside-animation when the counter ticks up").
+
+2. **Start the session.** Call `start_perception`. This auto-starts watch
+   (keyframe capture) if not already running. Record the `startedAt`
+   timestamp.
+
+3. **Drive the workflow.** Use existing MCP tools (`navigate`, `act` with
+   click/scroll/type/wait, etc.) to execute the steps. Wait long enough
+   between steps for perception to process — give 500ms-1s of buffer after
+   each action.
+
+4. **(Optional) Peek mid-flight.** For long workflows, call
+   `get_perception_session` partway through to see running stats. Useful
+   if a loop appears stuck.
+
+5. **Stop the session.** Call `stop_perception`. This returns the final
+   summary as JSON. Do NOT stop watch — leave keyframe capture running
+   for other consumers.
+
+6. **Pull the relevant timeline events.** Call `get_timeline` filtered to
+   `perception-tick`, `perception-anomaly`, `perception-escalation`,
+   `perception-intent-result` with `since: <startedAt>`. This gives the
+   detailed event sequence to back up the summary.
+
+7. **Produce a report.** Generate markdown with these sections:
+   - **Session overview**: duration, tick counts per tier, achieved vs target cadence
+   - **Anomalies**: timestamps, reasons, target nodes, count by reason
+   - **Escalations**: from-tier → to-tier counts
+   - **Intent results**: VLM classifications per region
+   - **VLM cost**: best-effort dollar estimate from `vlmCalls`
+   - **Assertions** (if user stated expectations): ✅ or ❌ per expectation,
+     with the relevant timeline snippet if it failed
+
+Make the report scannable. Use tables for repeated rows (anomalies,
+intent results). Quote specific timeline events when explaining failures.
+
+## What perception can detect today (v1)
+
+- **Anomaly trigger**: `mutation-outside-animation`. Fires when DOM
+  mutations happen while no CSS animation is active. Catches things like
+  JS-driven count-up animations, IntersectionObserver-triggered state
+  updates, React re-renders that change text content.
+- **Escalation chain**: frame loop → semantic loop → intent loop. Frame
+  spots the anomaly, semantic checks if the affected nodes are
+  unclassified components, intent classifies new components via VLM.
+
+## What perception does NOT yet detect (v1 limitations)
+
+- CSS `transition` (not `Animation` API) — false negatives.
+- Animation deviation, new component signatures, optical-flow motion
+  triggers — deferred to v2.
+- Mutations on subtree A while an animation runs on subtree B — global
+  temporal gate suppresses these as false negatives.
+
+Be honest about these limits in the report when relevant.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -556,7 +556,23 @@ export function createServer(config: ServerConfig = {}): McpServer {
       inputSchema: z.object({
         since: z.number().optional().describe('Only return events with timestamp >= since (stream-relative ms)'),
         types: z
-          .array(z.enum(['input', 'mutation', 'network-request', 'network-response', 'animation-start', 'animation-end', 'phash-change']))
+          .array(z.enum([
+            'input',
+            'mutation',
+            'network-request',
+            'network-response',
+            'animation-start',
+            'animation-end',
+            'animation-prediction',
+            'phash-change',
+            'optical-flow-raw',
+            'optical-flow-region',
+            'optical-flow-motion',
+            'perception-tick',
+            'perception-anomaly',
+            'perception-escalation',
+            'perception-intent-result',
+          ]))
           .optional()
           .describe('Filter by event types'),
       }),

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -32,6 +32,12 @@ import { Matcher } from '../pipelines/component-index/matcher.js';
 import { Indexer } from '../pipelines/component-index/indexer.js';
 import { classifyByVlm } from '../pipelines/component-index/vlm-classifier.js';
 import { makeGetComponentIndexTool } from './tools/get-component-index.js';
+import {
+  createPerceptionState,
+  makeStartPerceptionTool,
+  makeStopPerceptionTool,
+  makeGetPerceptionSessionTool,
+} from './tools/perception.js';
 
 const log = createLogger('mcp-server');
 const FLOW_BINARY_PATH = process.env.UIPE_FLOW_BINARY ??
@@ -56,6 +62,9 @@ export const TOOL_NAMES = [
   'stop_watch',
   'get_timeline',
   'get_component_index',
+  'start_perception',
+  'stop_perception',
+  'get_perception_session',
 ] as const;
 
 export function createServer(config: ServerConfig = {}): McpServer {
@@ -71,6 +80,7 @@ export function createServer(config: ServerConfig = {}): McpServer {
   const componentQueue = new ClassificationQueue();
   const componentMatcher = new Matcher({ store: componentStore, queue: componentQueue });
   const componentIndexer = new Indexer({ matcher: componentMatcher });
+  const perceptionState = createPerceptionState();
   const eventStream = new TemporalEventStream();
   let frameCapture: FrameCapture | null = null;
   let flowProducer: FlowProducer | null = null;
@@ -574,6 +584,97 @@ export function createServer(config: ServerConfig = {}): McpServer {
     async ({ origin }) => {
       const result = await componentIndexTool.handler({ origin });
       scheduleIdleDrain();
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // Tool 15: start_perception
+  const startPerceptionTool = makeStartPerceptionTool({
+    state: perceptionState,
+    ensureLaunched,
+    ensureWatchStarted: async () => {
+      // Mirror the watch tool's FrameCapture startup, but without returning a response.
+      // No-op if FrameCapture is already running.
+      if (frameCapture?.capturing) return;
+      await ensureLaunched();
+      frameCapture = new FrameCapture();
+      keyframeCount = 0;
+      watchStartTime = Date.now();
+      frameCapture.on('keyframe', async () => {
+        keyframeCount++;
+        try {
+          const graph = await captureGraph();
+          tracker.observe(graph);
+        } catch {
+          // Silently skip — frame capture continues
+        }
+      });
+      await frameCapture.start(runtime.getPage());
+      if (flowProducer) {
+        flowBridge = new EventEmitter();
+        flowBridgeListener = async (kf: { frame: Buffer; timestamp: number }) => {
+          if (!flowProducer || !flowBridge) return;
+          try {
+            const phash = await frameCapture!.perceptualHash(kf.frame);
+            flowBridge.emit('keyframe', { pngBytes: kf.frame, phash, timestamp: kf.timestamp });
+          } catch (err) {
+            log.warn('perceptualHash failed, skipping frame for optical-flow', { error: String(err) });
+          }
+        };
+        frameCapture.on('keyframe', flowBridgeListener);
+        flowProducer.attachFrameSource(flowBridge);
+      }
+    },
+    getEventStream: () => eventStream,
+    getSessionDeps: () => ({
+      page: runtime.getPage(),
+      frameCapture: frameCapture!,
+      indexer: componentIndexer,
+      structuralPipeline: structural,
+      classifyByVlm,
+      getScreenshot: () => runtime.screenshot().catch(() => null),
+    }),
+  });
+  server.registerTool(
+    startPerceptionTool.name,
+    {
+      title: 'Start Perception Session',
+      description: startPerceptionTool.description,
+      inputSchema: z.object({}),
+    },
+    async () => {
+      await ensureStreamAttached();
+      const result = await startPerceptionTool.handler({});
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // Tool 16: stop_perception
+  const stopPerceptionTool = makeStopPerceptionTool({ state: perceptionState });
+  server.registerTool(
+    stopPerceptionTool.name,
+    {
+      title: 'Stop Perception Session',
+      description: stopPerceptionTool.description,
+      inputSchema: z.object({}),
+    },
+    async () => {
+      const result = await stopPerceptionTool.handler({});
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // Tool 17: get_perception_session
+  const getPerceptionSessionTool = makeGetPerceptionSessionTool({ state: perceptionState });
+  server.registerTool(
+    getPerceptionSessionTool.name,
+    {
+      title: 'Get Perception Session',
+      description: getPerceptionSessionTool.description,
+      inputSchema: z.object({}),
+    },
+    async () => {
+      const result = await getPerceptionSessionTool.handler({});
       return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
     },
   );

--- a/src/mcp/tools/perception.ts
+++ b/src/mcp/tools/perception.ts
@@ -50,9 +50,16 @@ export function makeStartPerceptionTool(opts: StartOptions): StartPerceptionTool
       await opts.ensureLaunched();
       await opts.ensureWatchStarted();
       const eventStream = opts.getEventStream?.();
-      const session = eventStream
-        ? opts.state.createSession(eventStream)
-        : opts.state.createSession(null as unknown as TemporalEventStream);
+      if (!eventStream) {
+        // C4 fix: previously passed `null as unknown as TemporalEventStream`
+        // to createSession, producing a broken session that crashed inside
+        // start() with an opaque "cannot read property 'on' of null" error
+        // and left state.currentSession in an inconsistent shape.
+        throw new Error(
+          'start_perception: no TemporalEventStream available — call watch first or wire getEventStream on the tool factory',
+        );
+      }
+      const session = opts.state.createSession(eventStream);
       const deps = opts.getSessionDeps();
       const startedAt = Date.now();
       await session.start(startedAt, deps);

--- a/src/mcp/tools/perception.ts
+++ b/src/mcp/tools/perception.ts
@@ -55,7 +55,7 @@ export function makeStartPerceptionTool(opts: StartOptions): StartPerceptionTool
         : opts.state.createSession(null as unknown as TemporalEventStream);
       const deps = opts.getSessionDeps();
       const startedAt = Date.now();
-      session.start(startedAt, deps);
+      await session.start(startedAt, deps);
       opts.state.currentSession = session;
       return { status: 'started', startedAt };
     },

--- a/src/mcp/tools/perception.ts
+++ b/src/mcp/tools/perception.ts
@@ -1,0 +1,135 @@
+import { PerceptionSession, type SessionStartDeps } from '../../pipelines/perception/session.js';
+import type { TemporalEventStream } from '../../pipelines/temporal/event-stream.js';
+import type { PerceptionSessionSummary } from '../../pipelines/perception/types.js';
+
+export interface PerceptionState {
+  currentSession: PerceptionSession | null;
+  lastSummary: PerceptionSessionSummary | null;
+  /** Test seam: factory for creating a new PerceptionSession. */
+  createSession: (eventStream: TemporalEventStream) => PerceptionSession;
+}
+
+export function createPerceptionState(): PerceptionState {
+  return {
+    currentSession: null,
+    lastSummary: null,
+    createSession: (eventStream) => new PerceptionSession({ eventStream }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// start_perception
+// ---------------------------------------------------------------------------
+
+interface StartOptions {
+  state: PerceptionState;
+  ensureLaunched: () => Promise<void>;
+  ensureWatchStarted: () => Promise<void>;
+  getEventStream?: () => TemporalEventStream;
+  getSessionDeps: () => SessionStartDeps;
+}
+
+export interface StartPerceptionTool {
+  readonly name: 'start_perception';
+  readonly description: string;
+  readonly inputSchema: { type: 'object'; properties: Record<string, never>; required: never[] };
+  handler(args: Record<string, never>): Promise<{ status: 'started' | 'already-running'; startedAt: number }>;
+}
+
+export function makeStartPerceptionTool(opts: StartOptions): StartPerceptionTool {
+  return {
+    name: 'start_perception',
+    description:
+      'Begin a perception session. Starts the frame/semantic/intent loop hierarchy on the current page. Auto-starts watch (keyframe capture) if not already running. Use stop_perception to end the session and get a summary.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    async handler() {
+      const s = opts.state.currentSession;
+      if (s && s.isRunning()) {
+        return { status: 'already-running', startedAt: s.getStartedAt() };
+      }
+      await opts.ensureLaunched();
+      await opts.ensureWatchStarted();
+      const eventStream = opts.getEventStream?.();
+      const session = eventStream
+        ? opts.state.createSession(eventStream)
+        : opts.state.createSession(null as unknown as TemporalEventStream);
+      const deps = opts.getSessionDeps();
+      const startedAt = Date.now();
+      session.start(startedAt, deps);
+      opts.state.currentSession = session;
+      return { status: 'started', startedAt };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// stop_perception
+// ---------------------------------------------------------------------------
+
+interface StopOptions {
+  state: PerceptionState;
+}
+
+export interface StopPerceptionTool {
+  readonly name: 'stop_perception';
+  readonly description: string;
+  readonly inputSchema: { type: 'object'; properties: Record<string, never>; required: never[] };
+  handler(args: Record<string, never>): Promise<PerceptionSessionSummary | { error: string }>;
+}
+
+export function makeStopPerceptionTool(opts: StopOptions): StopPerceptionTool {
+  return {
+    name: 'stop_perception',
+    description:
+      "End the current perception session and return its summary (tick counts, anomalies, escalations, intent results, VLM cost). Does NOT stop watch — keyframe capture continues for non-perception consumers. If no session is running, returns the previous session's summary if available.",
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    async handler() {
+      const session = opts.state.currentSession;
+      if (session && session.isRunning()) {
+        session.stop(Date.now());
+        const summary = session.getSummary();
+        opts.state.lastSummary = summary;
+        opts.state.currentSession = null;
+        return summary;
+      }
+      if (opts.state.lastSummary) {
+        return opts.state.lastSummary;
+      }
+      return { error: 'No session active and no prior summary' };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// get_perception_session
+// ---------------------------------------------------------------------------
+
+interface GetOptions {
+  state: PerceptionState;
+}
+
+export interface GetPerceptionSessionTool {
+  readonly name: 'get_perception_session';
+  readonly description: string;
+  readonly inputSchema: { type: 'object'; properties: Record<string, never>; required: never[] };
+  handler(args: Record<string, never>): Promise<PerceptionSessionSummary | { error: string }>;
+}
+
+export function makeGetPerceptionSessionTool(opts: GetOptions): GetPerceptionSessionTool {
+  return {
+    name: 'get_perception_session',
+    description:
+      "Return the current perception session's summary if one is running. Otherwise return the last completed session's summary if any. Use this to inspect what perception is seeing mid-flight without stopping the session.",
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    async handler() {
+      const session = opts.state.currentSession;
+      if (session && session.isRunning()) {
+        return session.getSummary();
+      }
+      if (opts.state.lastSummary) {
+        return opts.state.lastSummary;
+      }
+      return { error: 'No session active and no prior summary' };
+    },
+  };
+}

--- a/src/pipelines/perception/anomaly/mutation-outside-animation.ts
+++ b/src/pipelines/perception/anomaly/mutation-outside-animation.ts
@@ -1,0 +1,80 @@
+/**
+ * A lightweight record of a single DOM mutation, maintained by FrameLoop's
+ * ring buffer. We don't reuse TimelineEvent<'mutation'> directly because the
+ * existing MutationPayload is a batched summary (counts only, no node IDs);
+ * FrameLoop enriches each observation with the node ID before storing it.
+ */
+export interface MutationRecord {
+  timestamp: number;
+  targetNodeId: string;
+}
+
+export interface DetectInput {
+  recentMutations: MutationRecord[];
+  activeAnimations: Set<string>;
+  nowMs: number;
+  sessionStartMs: number;
+}
+
+export interface DetectConfig {
+  lookbackMs: number;
+  coalesceWindowMs: number;
+  warmupMs: number;
+}
+
+export type DetectResult =
+  | null
+  | { mutationCount: number; targetNodeIds: string[] };
+
+export const DEFAULT_CONFIG: DetectConfig = {
+  lookbackMs: 200,
+  coalesceWindowMs: 100,
+  warmupMs: 500,
+};
+
+/**
+ * Pure detector for the v1 anomaly trigger. Returns a result when:
+ *   - past the warmup window
+ *   - no animation is currently active
+ *   - at least one mutation falls within the latest coalesced burst
+ *
+ * `recentMutations` is assumed to already be trimmed to `lookbackMs` by the
+ * caller (FrameLoop maintains a ring buffer).
+ */
+export function detectMutationOutsideAnimation(
+  input: DetectInput,
+  config: DetectConfig = DEFAULT_CONFIG,
+): DetectResult {
+  // 1. Warmup gate
+  if (input.nowMs - input.sessionStartMs < config.warmupMs) return null;
+
+  // 2. Active animation gate
+  if (input.activeAnimations.size > 0) return null;
+
+  // 3. Coalesce — group mutations into bursts, take the latest
+  if (input.recentMutations.length === 0) return null;
+
+  // Sort by timestamp ascending to make grouping deterministic
+  const sorted = [...input.recentMutations].sort((a, b) => a.timestamp - b.timestamp);
+
+  // Find the latest burst by walking backwards: include events while the gap
+  // to the previous event is ≤ coalesceWindowMs.
+  const latest = sorted[sorted.length - 1];
+  const burst: MutationRecord[] = [latest];
+  for (let i = sorted.length - 2; i >= 0; i--) {
+    const gap = burst[burst.length - 1].timestamp - sorted[i].timestamp;
+    if (gap > config.coalesceWindowMs) break;
+    burst.push(sorted[i]);
+  }
+
+  // 4. Empty short-circuit (defensive — shouldn't hit since we returned null above on empty)
+  if (burst.length === 0) return null;
+
+  // 5. Emit. Reverse burst to chronological order, then dedupe target IDs.
+  burst.reverse();
+  const uniqueIds = Array.from(new Set(burst.map((e) => e.targetNodeId)));
+  return {
+    mutationCount: burst.length,
+    targetNodeIds: uniqueIds,
+  };
+}

--- a/src/pipelines/perception/frame-loop.ts
+++ b/src/pipelines/perception/frame-loop.ts
@@ -62,6 +62,10 @@ export class FrameLoop {
   private recentMutations: MutationRecord[] = [];
   private lastAnomalyEmittedAt = -Infinity;
 
+  /** Once stop() is called, in-flight handler callbacks become no-ops.
+   *  Mirrors the running/stopped guard used by SemanticLoop + IntentLoop. */
+  private stopped = false;
+
   // Bound handlers so we can removeListener in stop().
   private readonly onKeyframe = (kf: KeyframeEvent): void => {
     this.handleKeyframe(kf.timestamp);
@@ -115,6 +119,7 @@ export class FrameLoop {
 
   /** Stop the loop and clean up subscriptions. */
   stop(): void {
+    this.stopped = true;
     if (this.page) {
       this.page.off('framenavigated', this.onFrameNavigated);
       // Remove this loop from the dispatcher so a future session starts clean.
@@ -245,6 +250,7 @@ export class FrameLoop {
   // ---------------------------------------------------------------------------
 
   private handleStreamEvent(e: TimelineEvent<EventType>): void {
+    if (this.stopped) return;
     if (e.type === 'animation-start') {
       const payload = (e as TimelineEvent<'animation-start'>).payload;
       this.activeAnimations.add(payload.animationId);
@@ -256,6 +262,7 @@ export class FrameLoop {
   }
 
   private handleKeyframe(nowMs: number): void {
+    if (this.stopped) return;
     // Trim ring buffer to lookback window.
     this.recentMutations = this.recentMutations.filter(
       (m) => nowMs - m.timestamp <= this.config.lookbackMs,

--- a/src/pipelines/perception/frame-loop.ts
+++ b/src/pipelines/perception/frame-loop.ts
@@ -81,14 +81,29 @@ export class FrameLoop {
   // installPageObserver (target closed mid-nav, evaluate timeout, etc.)
   // would become an unhandled rejection AND leave the loop firing keyframes
   // with zero mutations arriving. Catch + log so the failure is observable.
+  //
+  // P2-N1: discriminate known Playwright races from genuinely unexpected
+  // errors. A `TargetClosed` mid-nav is expected and shouldn't trip alarms;
+  // a TypeError from a refactor bug should be loud.
   private readonly onFrameNavigated = async (): Promise<void> => {
     if (!this.page) return;
     try {
       await this.installPageObserver(this.page);
     } catch (err) {
-      logger.error('FrameLoop: failed to reinstall page-side observer after navigation', {
-        error: err instanceof Error ? err.stack : String(err),
-      });
+      const msg = err instanceof Error ? err.message : String(err);
+      const stack = err instanceof Error ? err.stack : String(err);
+      const isKnownPlaywrightRace =
+        /target.*closed/i.test(msg) ||
+        /execution context.*destroyed/i.test(msg);
+      if (isKnownPlaywrightRace) {
+        logger.warn('FrameLoop: observer reinstall raced with page lifecycle (expected during nav)', {
+          error: stack,
+        });
+      } else {
+        logger.error('FrameLoop: UNEXPECTED error reinstalling page-side observer after navigation', {
+          error: stack,
+        });
+      }
     }
   };
 

--- a/src/pipelines/perception/frame-loop.ts
+++ b/src/pipelines/perception/frame-loop.ts
@@ -1,0 +1,241 @@
+/**
+ * FrameLoop — keyframe-driven perception tier.
+ *
+ * Wakes on every FrameCapture `keyframe` event. Tracks active animations by
+ * subscribing to `TemporalEventStream`'s `event` emitter (animation-start /
+ * animation-end). Collects per-node mutation records from a page-side
+ * MutationObserver (not from the batched MutationCollector, which only carries
+ * counters). Runs the pure `detectMutationOutsideAnimation` detector on each
+ * keyframe and emits anomaly + escalation events via `PerceptionSession`.
+ */
+
+import type { Page } from 'playwright';
+import type { FrameCapture } from '../visual/frame-capture.js';
+import type { TemporalEventStream } from '../temporal/event-stream.js';
+import type { TimelineEvent, EventType } from '../temporal/collectors/types.js';
+import type { KeyframeEvent } from '../../types/temporal.js';
+import type { PerceptionSession } from './session.js';
+import {
+  detectMutationOutsideAnimation,
+  DEFAULT_CONFIG,
+  type DetectConfig,
+  type MutationRecord,
+} from './anomaly/mutation-outside-animation.js';
+
+// Payload sent from the page side per mutation.
+interface PageMutationPayload {
+  timestamp: number;
+  targetNodeId: string;
+}
+
+export interface FrameLoopOptions {
+  session: PerceptionSession;
+  frameCapture: FrameCapture;
+  eventStream: TemporalEventStream;
+  /** Optional: provide a Playwright Page to install the page-side observer. */
+  page?: Page;
+  config?: Partial<DetectConfig>;
+}
+
+export class FrameLoop {
+  private readonly session: PerceptionSession;
+  private readonly frameCapture: FrameCapture;
+  private readonly eventStream: TemporalEventStream;
+  private readonly page: Page | undefined;
+  private readonly config: DetectConfig;
+
+  private activeAnimations = new Set<string>();
+  private recentMutations: MutationRecord[] = [];
+  private lastAnomalyEmittedAt = -Infinity;
+
+  // Bound handlers so we can removeListener in stop().
+  private readonly onKeyframe = (kf: KeyframeEvent): void => {
+    this.handleKeyframe(kf.timestamp);
+  };
+
+  private readonly onStreamEvent = (e: TimelineEvent<EventType>): void => {
+    this.handleStreamEvent(e);
+  };
+
+  constructor(opts: FrameLoopOptions) {
+    this.session = opts.session;
+    this.frameCapture = opts.frameCapture;
+    this.eventStream = opts.eventStream;
+    this.page = opts.page;
+    this.config = { ...DEFAULT_CONFIG, ...opts.config };
+  }
+
+  /**
+   * Start the loop. Installs the page-side MutationObserver (if a page was
+   * provided), subscribes to FrameCapture keyframes and stream events.
+   */
+  async start(): Promise<void> {
+    if (this.page) {
+      await this.installPageObserver(this.page);
+    }
+    this.frameCapture.on('keyframe', this.onKeyframe);
+    this.eventStream.on('event', this.onStreamEvent);
+  }
+
+  /** Stop the loop and clean up subscriptions. */
+  stop(): void {
+    this.frameCapture.off('keyframe', this.onKeyframe);
+    this.eventStream.off('event', this.onStreamEvent);
+    this.activeAnimations.clear();
+    this.recentMutations = [];
+    this.lastAnomalyEmittedAt = -Infinity;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test seams
+  // ---------------------------------------------------------------------------
+
+  /** Push a synthetic mutation record — used in unit tests instead of the
+   * page-side observer. */
+  addMutationForTest(timestamp: number, targetNodeId: string): void {
+    this.recentMutations.push({ timestamp, targetNodeId });
+  }
+
+  /** Expose active-animation set for test assertions. */
+  getActiveAnimationsForTest(): Set<string> {
+    return this.activeAnimations;
+  }
+
+  /** Expose recent-mutation ring buffer for test assertions. */
+  getRecentMutationsForTest(): MutationRecord[] {
+    return this.recentMutations;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Page-side observer
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Installs a per-node MutationObserver on the page. Each mutation record
+   * gets a synthetic ID via a WeakMap to avoid touching the DOM. The ID is
+   * sent back over an exposed function.
+   *
+   * Strategy mirrors MutationCollector's pattern (exposeFunction +
+   * page.evaluate guard) but emits one record per mutation rather than
+   * batched counters.
+   */
+  private async installPageObserver(page: Page): Promise<void> {
+    const self = this;
+
+    try {
+      await page.exposeFunction(
+        '__uipeFrameLoopMutation',
+        (payload: PageMutationPayload) => {
+          self.recentMutations.push({
+            timestamp: payload.timestamp,
+            targetNodeId: payload.targetNodeId,
+          });
+        },
+      );
+    } catch (err) {
+      const msg = (err as Error).message ?? '';
+      if (!msg.includes('registered')) {
+        throw err;
+      }
+      // Already registered from a prior attach — the closure above still
+      // captures the new FrameLoop instance so mutations route correctly.
+    }
+
+    await page.evaluate(() => {
+      const win = window as any;
+      if (win.__uipeFrameLoopMutationInstalled) return;
+      win.__uipeFrameLoopMutationInstalled = true;
+
+      // WeakMap keeps synthetic IDs without touching DOM attributes.
+      const nodeIds = new WeakMap<Node, string>();
+      let counter = 0;
+
+      const getNodeId = (node: Node): string => {
+        let id = nodeIds.get(node);
+        if (!id) {
+          id = `mut-${counter++}`;
+          nodeIds.set(node, id);
+        }
+        return id;
+      };
+
+      const observer = new MutationObserver((records) => {
+        const now = Date.now();
+        for (const r of records) {
+          const targetNodeId = getNodeId(r.target);
+          (win.__uipeFrameLoopMutation as (p: { timestamp: number; targetNodeId: string }) => void)?.({
+            timestamp: now,
+            targetNodeId,
+          });
+        }
+      });
+
+      observer.observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        characterData: true,
+      });
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Event handlers
+  // ---------------------------------------------------------------------------
+
+  private handleStreamEvent(e: TimelineEvent<EventType>): void {
+    if (e.type === 'animation-start') {
+      const payload = (e as TimelineEvent<'animation-start'>).payload;
+      this.activeAnimations.add(payload.animationId);
+    } else if (e.type === 'animation-end') {
+      const payload = (e as TimelineEvent<'animation-end'>).payload;
+      this.activeAnimations.delete(payload.animationId);
+    }
+    // Mutations are sourced from the page-side observer, not the stream.
+  }
+
+  private handleKeyframe(nowMs: number): void {
+    // Trim ring buffer to lookback window.
+    this.recentMutations = this.recentMutations.filter(
+      (m) => nowMs - m.timestamp <= this.config.lookbackMs,
+    );
+
+    // Record the frame-tier tick.
+    this.session.recordTick('frame', 'keyframe', nowMs);
+
+    // Debounce: skip detector if we emitted an anomaly very recently.
+    if (nowMs - this.lastAnomalyEmittedAt <= this.config.coalesceWindowMs) {
+      return;
+    }
+
+    const result = detectMutationOutsideAnimation(
+      {
+        recentMutations: this.recentMutations,
+        activeAnimations: this.activeAnimations,
+        nowMs,
+        sessionStartMs: this.session.getStartedAt(),
+      },
+      this.config,
+    );
+
+    if (!result) return;
+
+    this.lastAnomalyEmittedAt = nowMs;
+
+    // v1: no bbox info available at this tier; semantic loop resolves bboxes.
+    const regions = result.targetNodeIds.map((nodeId) => ({
+      nodeId,
+      bbox: { x: 0, y: 0, w: 0, h: 0 },
+    }));
+
+    this.session.recordAnomaly('frame', 'mutation-outside-animation', result, nowMs);
+    this.session.recordEscalation(
+      'frame',
+      'semantic',
+      'mutation-outside-animation',
+      regions,
+      nowMs,
+    );
+    this.session.internalEmitter.emit('escalate', { from: 'frame', regions });
+  }
+}

--- a/src/pipelines/perception/frame-loop.ts
+++ b/src/pipelines/perception/frame-loop.ts
@@ -37,6 +37,17 @@ export interface FrameLoopOptions {
   config?: Partial<DetectConfig>;
 }
 
+// ---------------------------------------------------------------------------
+// Module-level WeakMap dispatcher (Fix 2: second-session mutation routing).
+//
+// When page.exposeFunction throws "already registered", the OLD closure is
+// still bound on the page. Using a WeakMap keyed by Page lets the page-side
+// function look up the *current* FrameLoop owner, so second (and later)
+// sessions receive their mutations correctly.
+// ---------------------------------------------------------------------------
+type FrameLoopDispatch = (payload: PageMutationPayload) => void;
+const frameLoopDispatchers = new WeakMap<Page, FrameLoopDispatch>();
+
 export class FrameLoop {
   private readonly session: PerceptionSession;
   private readonly frameCapture: FrameCapture;
@@ -57,6 +68,13 @@ export class FrameLoop {
     this.handleStreamEvent(e);
   };
 
+  // Reinstalls the page-side observer after SPA navigation (Fix 1).
+  private readonly onFrameNavigated = async (): Promise<void> => {
+    if (this.page) {
+      await this.installPageObserver(this.page);
+    }
+  };
+
   constructor(opts: FrameLoopOptions) {
     this.session = opts.session;
     this.frameCapture = opts.frameCapture;
@@ -67,11 +85,16 @@ export class FrameLoop {
 
   /**
    * Start the loop. Installs the page-side MutationObserver (if a page was
-   * provided), subscribes to FrameCapture keyframes and stream events.
+   * provided), subscribes to FrameCapture keyframes, stream events, and
+   * framenavigated (to reinstall after SPA route changes).
    */
   async start(): Promise<void> {
     if (this.page) {
       await this.installPageObserver(this.page);
+      // Fix 1: subscribe to navigation so the observer is reinstalled after
+      // each SPA route change. The session's onPageNav also fires but only
+      // resets startedAt — these two handlers are independent.
+      this.page.on('framenavigated', this.onFrameNavigated);
     }
     this.frameCapture.on('keyframe', this.onKeyframe);
     this.eventStream.on('event', this.onStreamEvent);
@@ -79,6 +102,11 @@ export class FrameLoop {
 
   /** Stop the loop and clean up subscriptions. */
   stop(): void {
+    if (this.page) {
+      this.page.off('framenavigated', this.onFrameNavigated);
+      // Remove this loop from the dispatcher so a future session starts clean.
+      frameLoopDispatchers.delete(this.page);
+    }
     this.frameCapture.off('keyframe', this.onKeyframe);
     this.eventStream.off('event', this.onStreamEvent);
     this.activeAnimations.clear();
@@ -118,18 +146,33 @@ export class FrameLoop {
    * Strategy mirrors MutationCollector's pattern (exposeFunction +
    * page.evaluate guard) but emits one record per mutation rather than
    * batched counters.
+   *
+   * Fix 2: uses a module-level WeakMap dispatcher so that when
+   * exposeFunction throws "already registered" (because a prior FrameLoop
+   * left the binding), the page-side closure still routes to *this* instance.
+   *
+   * Fix 1: also called on every `framenavigated` event so mutations are
+   * not silently lost after SPA route changes (which destroy the page-side
+   * flag + observer).
    */
   private async installPageObserver(page: Page): Promise<void> {
-    const self = this;
+    // Register this instance as the current dispatcher for this Page.
+    frameLoopDispatchers.set(page, (payload: PageMutationPayload) => {
+      this.recentMutations.push({
+        timestamp: payload.timestamp,
+        targetNodeId: payload.targetNodeId,
+      });
+    });
 
     try {
+      // The stable closure looks up the current dispatcher via the WeakMap,
+      // so a second (or later) FrameLoop session automatically gets its
+      // mutations even though the function binding is from the first session.
       await page.exposeFunction(
         '__uipeFrameLoopMutation',
         (payload: PageMutationPayload) => {
-          self.recentMutations.push({
-            timestamp: payload.timestamp,
-            targetNodeId: payload.targetNodeId,
-          });
+          const fn = frameLoopDispatchers.get(page);
+          if (fn) fn(payload);
         },
       );
     } catch (err) {
@@ -137,10 +180,15 @@ export class FrameLoop {
       if (!msg.includes('registered')) {
         throw err;
       }
-      // Already registered from a prior attach — the closure above still
-      // captures the new FrameLoop instance so mutations route correctly.
+      // Already registered from a prior attach. The WeakMap dispatcher above
+      // ensures the old closure now routes to this FrameLoop instance.
+      // Note: DEFERRED — only the FIRST session on a given page lifecycle
+      // works correctly; subsequent sessions on the same page lifetime are
+      // handled by the WeakMap redirect. See spec follow-up for full fix.
     }
 
+    // After navigation the flag is gone — always re-run evaluate so the
+    // MutationObserver is reinstalled on the new document.
     await page.evaluate(() => {
       const win = window as any;
       if (win.__uipeFrameLoopMutationInstalled) return;

--- a/src/pipelines/perception/frame-loop.ts
+++ b/src/pipelines/perception/frame-loop.ts
@@ -15,12 +15,15 @@ import type { TemporalEventStream } from '../temporal/event-stream.js';
 import type { TimelineEvent, EventType } from '../temporal/collectors/types.js';
 import type { KeyframeEvent } from '../../types/temporal.js';
 import type { PerceptionSession } from './session.js';
+import { createLogger } from '../../utils/logger.js';
 import {
   detectMutationOutsideAnimation,
   DEFAULT_CONFIG,
   type DetectConfig,
   type MutationRecord,
 } from './anomaly/mutation-outside-animation.js';
+
+const logger = createLogger('PerceptionFrameLoop');
 
 // Payload sent from the page side per mutation.
 interface PageMutationPayload {
@@ -69,9 +72,19 @@ export class FrameLoop {
   };
 
   // Reinstalls the page-side observer after SPA navigation (Fix 1).
+  //
+  // Playwright invokes this listener fire-and-forget — any throw from
+  // installPageObserver (target closed mid-nav, evaluate timeout, etc.)
+  // would become an unhandled rejection AND leave the loop firing keyframes
+  // with zero mutations arriving. Catch + log so the failure is observable.
   private readonly onFrameNavigated = async (): Promise<void> => {
-    if (this.page) {
+    if (!this.page) return;
+    try {
       await this.installPageObserver(this.page);
+    } catch (err) {
+      logger.error('FrameLoop: failed to reinstall page-side observer after navigation', {
+        error: err instanceof Error ? err.stack : String(err),
+      });
     }
   };
 

--- a/src/pipelines/perception/intent-loop.ts
+++ b/src/pipelines/perception/intent-loop.ts
@@ -104,8 +104,11 @@ export class IntentLoop {
 
     try {
       // One tick per drain cycle, not per region.
+      // Guard: if stop() was called while we were awaiting, skip recording.
       const tickAt = Date.now();
-      this.session.recordTick('intent', 'escalation', tickAt);
+      if (this.running) {
+        this.session.recordTick('intent', 'escalation', tickAt);
+      }
 
       const screenshot = await this.getScreenshot();
       if (!screenshot) {
@@ -125,12 +128,15 @@ export class IntentLoop {
           const crop = await cropToBbox(screenshot, item.bbox);
           const classification = await this.classify({ html: '', screenshotCrop: crop });
           const duration = Date.now() - start;
-          this.session.recordIntentResult(
-            { nodeId: item.nodeId, bbox: item.bbox },
-            classification,
-            duration,
-            Date.now(),
-          );
+          // Fix 5: guard against stop() arriving during the classify await.
+          if (this.running) {
+            this.session.recordIntentResult(
+              { nodeId: item.nodeId, bbox: item.bbox },
+              classification,
+              duration,
+              Date.now(),
+            );
+          }
         } catch (err) {
           logger.warn('IntentLoop: per-region classification failed, skipping', {
             nodeId: item.nodeId,

--- a/src/pipelines/perception/intent-loop.ts
+++ b/src/pipelines/perception/intent-loop.ts
@@ -98,6 +98,9 @@ export class IntentLoop {
   }
 
   private async drain(): Promise<void> {
+    // C1 belt-and-suspenders: skip even if a stale escalate kicked off a
+    // drain between `running = false` and `internalEmitter.off(...)` in stop().
+    if (!this.running) return;
     if (this.draining) return;
     if (this.pending.length === 0) return;
     this.draining = true;
@@ -110,9 +113,25 @@ export class IntentLoop {
         this.session.recordTick('intent', 'escalation', tickAt);
       }
 
-      const screenshot = await this.getScreenshot();
+      let screenshot: Buffer | null;
+      try {
+        screenshot = await this.getScreenshot();
+      } catch (err) {
+        // Silent-failure #5: a throwing screenshot provider previously
+        // escaped via `void this.drain()` with zero feedback.
+        logger.error('IntentLoop: screenshot provider threw; dropping pending queue', {
+          error: err instanceof Error ? err.stack : String(err),
+          dropped: this.pending.length,
+        });
+        this.pending = [];
+        return;
+      }
       if (!screenshot) {
-        // Can't classify without a screenshot — drop all pending.
+        // Can't classify without a screenshot — drop all pending. Log so the
+        // failure is visible; previously this branch was silent.
+        logger.warn('IntentLoop: screenshot provider returned null; dropping pending queue', {
+          dropped: this.pending.length,
+        });
         this.pending = [];
         return;
       }

--- a/src/pipelines/perception/intent-loop.ts
+++ b/src/pipelines/perception/intent-loop.ts
@@ -17,6 +17,12 @@ import type { PerceptionSession } from './session.js';
 
 const logger = createLogger('PerceptionIntentLoop');
 
+/** P2-C1: cap per-failure ERROR logs when getScreenshot perma-throws.
+ *  Above the threshold we emit one "suppressing further logs" notice and
+ *  then go silent on logging (but still drop pending). The streak resets
+ *  on the first successful screenshot. */
+const SCREENSHOT_ERROR_LOG_THRESHOLD = 3;
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -53,6 +59,7 @@ export class IntentLoop {
   private pending: PendingItem[] = [];
   private draining = false;
   private running = false;
+  private screenshotErrorStreak = 0;
 
   // Arrow function so we can pass it directly to on/off without binding.
   private readonly onEscalate = (payload: { from: string; regions: PendingItem[] }): void => {
@@ -117,12 +124,23 @@ export class IntentLoop {
       try {
         screenshot = await this.getScreenshot();
       } catch (err) {
-        // Silent-failure #5: a throwing screenshot provider previously
-        // escaped via `void this.drain()` with zero feedback.
-        logger.error('IntentLoop: screenshot provider threw; dropping pending queue', {
-          error: err instanceof Error ? err.stack : String(err),
-          dropped: this.pending.length,
-        });
+        // P2-C1: bound log volume so a perma-throwing screenshot provider
+        // doesn't spam ERROR per escalation for the rest of the session.
+        // Below threshold → normal error log. AT threshold+1 → one "suppressing"
+        // notice. Above → silent (still drops pending).
+        this.screenshotErrorStreak += 1;
+        if (this.screenshotErrorStreak <= SCREENSHOT_ERROR_LOG_THRESHOLD) {
+          logger.error('IntentLoop: screenshot provider threw; dropping pending queue', {
+            error: err instanceof Error ? err.stack : String(err),
+            dropped: this.pending.length,
+            streak: this.screenshotErrorStreak,
+          });
+        } else if (this.screenshotErrorStreak === SCREENSHOT_ERROR_LOG_THRESHOLD + 1) {
+          logger.error(
+            'IntentLoop: screenshot provider repeatedly throwing; suppressing further per-failure logs until next success',
+            { streak: this.screenshotErrorStreak },
+          );
+        }
         this.pending = [];
         return;
       }
@@ -135,6 +153,9 @@ export class IntentLoop {
         this.pending = [];
         return;
       }
+      // Screenshot succeeded — reset the error streak so future failures
+      // log normally again.
+      this.screenshotErrorStreak = 0;
 
       // Snapshot the queue and reset it so new arrivals during the drain
       // accumulate independently and trigger a follow-up drain.

--- a/src/pipelines/perception/intent-loop.ts
+++ b/src/pipelines/perception/intent-loop.ts
@@ -1,0 +1,164 @@
+/**
+ * IntentLoop — event-driven intent tier.
+ *
+ * Wakes only on semantic→intent escalations (internalEmitter 'escalate' with
+ * `from: 'semantic'`). For each escalated region, it crops the latest screenshot
+ * via sharp and calls the injected VLM classifier. Results are written to the
+ * event stream via session.recordIntentResult.
+ *
+ * Backpressure: if pending items exceed maxPending, the oldest is dropped so the
+ * queue never grows unbounded.
+ */
+
+import sharp from 'sharp';
+import { createLogger } from '../../utils/logger.js';
+import type { TemporalEventStream } from '../temporal/event-stream.js';
+import type { PerceptionSession } from './session.js';
+
+const logger = createLogger('PerceptionIntentLoop');
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type ClassifyByVlmFn = (args: { html: string; screenshotCrop: Buffer }) => Promise<string>;
+
+export interface IntentLoopOptions {
+  session: PerceptionSession;
+  eventStream: TemporalEventStream;
+  getScreenshot: () => Promise<Buffer | null>;
+  classifyByVlm: ClassifyByVlmFn;
+  config?: { maxPending?: number };
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+interface PendingItem {
+  nodeId: string;
+  bbox: { x: number; y: number; w: number; h: number };
+}
+
+// ---------------------------------------------------------------------------
+// IntentLoop
+// ---------------------------------------------------------------------------
+
+export class IntentLoop {
+  private readonly session: PerceptionSession;
+  private readonly getScreenshot: () => Promise<Buffer | null>;
+  private readonly classify: ClassifyByVlmFn;
+  private readonly maxPending: number;
+
+  private pending: PendingItem[] = [];
+  private draining = false;
+  private running = false;
+
+  // Arrow function so we can pass it directly to on/off without binding.
+  private readonly onEscalate = (payload: { from: string; regions: PendingItem[] }): void => {
+    if (payload.from !== 'semantic') return;
+    for (const region of payload.regions) {
+      this.enqueue(region);
+    }
+    void this.drain();
+  };
+
+  constructor(opts: IntentLoopOptions) {
+    this.session = opts.session;
+    this.getScreenshot = opts.getScreenshot;
+    this.classify = opts.classifyByVlm;
+    this.maxPending = opts.config?.maxPending ?? 10;
+  }
+
+  start(): void {
+    this.running = true;
+    this.session.internalEmitter.on('escalate', this.onEscalate);
+  }
+
+  stop(): void {
+    this.running = false;
+    this.session.internalEmitter.off('escalate', this.onEscalate);
+    this.pending = [];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  private enqueue(item: PendingItem): void {
+    // Enqueue first, then drop oldest if over limit.
+    this.pending.push(item);
+    if (this.pending.length > this.maxPending) {
+      const dropped = this.pending.shift();
+      logger.warn('IntentLoop: dropping oldest pending region due to backpressure', {
+        dropped: dropped?.nodeId,
+        pendingCount: this.pending.length,
+      });
+    }
+  }
+
+  private async drain(): Promise<void> {
+    if (this.draining) return;
+    if (this.pending.length === 0) return;
+    this.draining = true;
+
+    try {
+      // One tick per drain cycle, not per region.
+      const tickAt = Date.now();
+      this.session.recordTick('intent', 'escalation', tickAt);
+
+      const screenshot = await this.getScreenshot();
+      if (!screenshot) {
+        // Can't classify without a screenshot — drop all pending.
+        this.pending = [];
+        return;
+      }
+
+      // Snapshot the queue and reset it so new arrivals during the drain
+      // accumulate independently and trigger a follow-up drain.
+      const items = this.pending.splice(0);
+
+      for (const item of items) {
+        if (!this.running) break;
+        const start = Date.now();
+        try {
+          const crop = await cropToBbox(screenshot, item.bbox);
+          const classification = await this.classify({ html: '', screenshotCrop: crop });
+          const duration = Date.now() - start;
+          this.session.recordIntentResult(
+            { nodeId: item.nodeId, bbox: item.bbox },
+            classification,
+            duration,
+            Date.now(),
+          );
+        } catch (err) {
+          logger.warn('IntentLoop: per-region classification failed, skipping', {
+            nodeId: item.nodeId,
+            error: String(err),
+          });
+        }
+      }
+    } finally {
+      this.draining = false;
+      // If new items arrived while we were draining, kick off another cycle.
+      if (this.pending.length > 0 && this.running) {
+        void this.drain();
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function cropToBbox(
+  png: Buffer,
+  bbox: { x: number; y: number; w: number; h: number },
+): Promise<Buffer> {
+  const left = Math.max(0, Math.round(bbox.x));
+  const top = Math.max(0, Math.round(bbox.y));
+  const width = Math.max(1, Math.round(bbox.w));
+  const height = Math.max(1, Math.round(bbox.h));
+  return sharp(png).extract({ left, top, width, height }).png().toBuffer();
+}

--- a/src/pipelines/perception/intent-loop.ts
+++ b/src/pipelines/perception/intent-loop.ts
@@ -181,7 +181,12 @@ export class IntentLoop {
           // I2 fix: preserve stack so VLM timeouts / sharp crashes / model
           // errors are distinguishable in logs. Also count the failure so
           // a 100%-failed session is visible in the summary.
-          this.session.recordVlmError();
+          // P2-I1 fix: gate on this.running so a late rejection after stop()
+          // doesn't bump the metric on a torn-down session — mirroring the
+          // success-path guard on recordIntentResult.
+          if (this.running) {
+            this.session.recordVlmError();
+          }
           logger.warn('IntentLoop: per-region classification failed, skipping', {
             nodeId: item.nodeId,
             error: err instanceof Error ? err.stack : String(err),

--- a/src/pipelines/perception/intent-loop.ts
+++ b/src/pipelines/perception/intent-loop.ts
@@ -157,9 +157,13 @@ export class IntentLoop {
             );
           }
         } catch (err) {
+          // I2 fix: preserve stack so VLM timeouts / sharp crashes / model
+          // errors are distinguishable in logs. Also count the failure so
+          // a 100%-failed session is visible in the summary.
+          this.session.recordVlmError();
           logger.warn('IntentLoop: per-region classification failed, skipping', {
             nodeId: item.nodeId,
-            error: String(err),
+            error: err instanceof Error ? err.stack : String(err),
           });
         }
       }

--- a/src/pipelines/perception/semantic-loop.ts
+++ b/src/pipelines/perception/semantic-loop.ts
@@ -1,0 +1,137 @@
+/**
+ * SemanticLoop — cadence-bounded semantic tier.
+ *
+ * Wakes when the frame loop escalates (via session.internalEmitter 'escalate'
+ * events with `from: 'frame'`). On wake, it runs the full structural pipeline
+ * + Indexer to find unclassified nodes, then escalates any pending nodes to
+ * the intent tier.
+ *
+ * Design decision (option A): ignores the `regions[*].nodeId` from frame
+ * escalation — those are synthetic `mut-N` IDs that don't map to structural
+ * pipeline `dom-N` IDs. Instead, we do a full re-run and let the indexer's
+ * output drive what gets escalated.
+ */
+
+import type { Page } from 'playwright';
+import type { StructuralPipeline } from '../structural/index.js';
+import type { Indexer } from '../component-index/indexer.js';
+import type { TemporalEventStream } from '../temporal/event-stream.js';
+import type { PerceptionSession } from './session.js';
+
+export interface SemanticLoopOptions {
+  session: PerceptionSession;
+  eventStream: TemporalEventStream;
+  indexer: Indexer;
+  structuralPipeline: StructuralPipeline;
+  page: Page;
+  config?: { cadenceMs?: number };
+}
+
+const DEFAULT_CADENCE_MS = 200;
+
+export class SemanticLoop {
+  private readonly session: PerceptionSession;
+  private readonly indexer: Indexer;
+  private readonly structuralPipeline: StructuralPipeline;
+  private readonly page: Page;
+  private readonly cadenceMs: number;
+
+  /** True when the loop has seen at least one frame escalation since the last tick. */
+  private hasPendingEscalation = false;
+  /** Wall-clock time of the most recent semantic tick (ms). 0 = never ticked. */
+  private lastTickMs = 0;
+  /** Whether stop() has been called. */
+  private stopped = false;
+
+  private readonly escalateHandler: (payload: { from: string; regions: unknown[] }) => void;
+
+  constructor(options: SemanticLoopOptions) {
+    this.session = options.session;
+    this.indexer = options.indexer;
+    this.structuralPipeline = options.structuralPipeline;
+    this.page = options.page;
+    this.cadenceMs = options.config?.cadenceMs ?? DEFAULT_CADENCE_MS;
+
+    this.escalateHandler = (payload) => {
+      if (payload.from !== 'frame') return;
+      if (this.stopped) return;
+      this.hasPendingEscalation = true;
+      // Schedule a wake immediately; cadence gate prevents double-firing.
+      this.scheduleWake();
+    };
+  }
+
+  start(): void {
+    this.stopped = false;
+    this.session.internalEmitter.on('escalate', this.escalateHandler);
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.session.internalEmitter.off('escalate', this.escalateHandler);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  private scheduleWake(): void {
+    const nowMs = Date.now();
+    const elapsed = nowMs - this.lastTickMs;
+    const delay = elapsed >= this.cadenceMs ? 0 : this.cadenceMs - elapsed;
+    setTimeout(() => {
+      if (this.stopped) return;
+      if (!this.hasPendingEscalation) return;
+      this.hasPendingEscalation = false;
+      void this.tick();
+    }, delay);
+  }
+
+  private async tick(): Promise<void> {
+    if (this.stopped) return;
+
+    const nowMs = Date.now();
+    // Enforce cadence: if another tick ran too recently, skip.
+    if (nowMs - this.lastTickMs < this.cadenceMs && this.lastTickMs !== 0) return;
+    this.lastTickMs = nowMs;
+
+    this.session.recordTick('semantic', 'escalation', nowMs);
+
+    // Run the full structural + indexer pipeline.
+    const structural = await this.structuralPipeline.extractStructure(this.page);
+    const componentMap = await this.indexer.run(structural, {
+      origin: (this.page as any).url?.() ?? 'unknown',
+    });
+
+    // Build a lookup from node id → structural node for bbox resolution.
+    const nodeById = new Map(structural.map((n) => [n.id, n]));
+
+    // Collect nodes the indexer marked as pending (unclassified).
+    const pendingRegions: Array<{ nodeId: string; bbox: { x: number; y: number; w: number; h: number } }> = [];
+    for (const [nodeId, field] of componentMap) {
+      if (field.name === null && (field as any).status === 'pending') {
+        const node = nodeById.get(nodeId);
+        const bb = node?.boundingBox ?? { x: 0, y: 0, width: 0, height: 0 };
+        pendingRegions.push({
+          nodeId,
+          bbox: { x: bb.x, y: bb.y, w: bb.width, h: bb.height },
+        });
+      }
+    }
+
+    if (pendingRegions.length === 0) return;
+
+    // Escalate to intent tier.
+    this.session.recordEscalation(
+      'semantic',
+      'intent',
+      'mutation-outside-animation',
+      pendingRegions,
+      nowMs,
+    );
+    this.session.internalEmitter.emit('escalate', {
+      from: 'semantic',
+      regions: pendingRegions,
+    });
+  }
+}

--- a/src/pipelines/perception/semantic-loop.ts
+++ b/src/pipelines/perception/semantic-loop.ts
@@ -47,6 +47,12 @@ export class SemanticLoop {
   private stopped = false;
   /** Pending wake timer — tracked so stop() can clear it. */
   private wakeTimer: ReturnType<typeof setTimeout> | null = null;
+  /** P2-H1: blocks re-entrant tick() while a previous tick is still awaiting.
+   *  The cadence gate's `lastTickMs !== 0` carve-out is insufficient on the
+   *  very first tick — a second escalate arriving mid-await would otherwise
+   *  bypass the gate (lastTickMs is still 0 until success) and run
+   *  concurrently. */
+  private inFlight = false;
 
   private readonly escalateHandler: (payload: { from: string; regions: unknown[] }) => void;
 
@@ -85,6 +91,11 @@ export class SemanticLoop {
   // ---------------------------------------------------------------------------
 
   private scheduleWake(): void {
+    // P2-I2: coalesce. A burst of escalates in the same JS turn previously
+    // overwrote this.wakeTimer without clearing the prior handle, leaking
+    // Node timer references. The pending state (hasPendingEscalation) is
+    // already aggregated, so a second timer is just noise.
+    if (this.wakeTimer !== null) return;
     const nowMs = Date.now();
     const elapsed = nowMs - this.lastTickMs;
     const delay = elapsed >= this.cadenceMs ? 0 : this.cadenceMs - elapsed;
@@ -99,18 +110,22 @@ export class SemanticLoop {
 
   private async tick(): Promise<void> {
     if (this.stopped) return;
+    // P2-H1: prevent concurrent re-entry while a previous tick is still
+    // awaiting (the first-tick cadence carve-out is otherwise too permissive).
+    if (this.inFlight) return;
 
     const nowMs = Date.now();
     // Enforce cadence: if another tick ran too recently, skip.
     if (nowMs - this.lastTickMs < this.cadenceMs && this.lastTickMs !== 0) return;
 
-    this.session.recordTick('semantic', 'escalation', nowMs);
-
-    // I3 fix: previously the awaited body ran without a catch — a throw from
-    // extractStructure / indexer.run became an unhandled rejection AND
-    // lastTickMs was already advanced (silently gating out the next
-    // escalation). Now we only advance lastTickMs on success.
+    this.inFlight = true;
     try {
+      // I3 + P2-H2 fix: previously recordTick ran BEFORE the try, so a failed
+      // tick still bumped tickCounts.semantic ("ghost ticks"). Plus the
+      // awaited body had no catch — a throw from extractStructure /
+      // indexer.run became an unhandled rejection AND lastTickMs was already
+      // advanced (silently gating out the next escalation). Now both
+      // recordTick and lastTickMs advance only on success.
       const structural = await this.structuralPipeline.extractStructure(this.page);
       const componentMap = await this.indexer.run(structural, {
         origin: this.page.url(),
@@ -132,7 +147,9 @@ export class SemanticLoop {
         }
       }
 
-      // Tick succeeded — advance the cadence gate now (not before the await).
+      // Tick succeeded — record the tick + advance the cadence gate now
+      // (not before the await).
+      this.session.recordTick('semantic', 'escalation', nowMs);
       this.lastTickMs = nowMs;
 
       if (pendingRegions.length === 0) return;
@@ -153,8 +170,11 @@ export class SemanticLoop {
       logger.warn('SemanticLoop: tick failed; will retry on next escalation', {
         error: err instanceof Error ? err.stack : String(err),
       });
-      // lastTickMs intentionally not advanced — the next escalation that
-      // arrives can re-enter tick() without being gated out.
+      // tickCounts.semantic and lastTickMs intentionally not advanced — the
+      // next escalation can re-enter tick() without being gated out, and the
+      // summary doesn't record a tick that did no work.
+    } finally {
+      this.inFlight = false;
     }
   }
 }

--- a/src/pipelines/perception/semantic-loop.ts
+++ b/src/pipelines/perception/semantic-loop.ts
@@ -17,6 +17,9 @@ import type { StructuralPipeline } from '../structural/index.js';
 import type { Indexer } from '../component-index/indexer.js';
 import type { TemporalEventStream } from '../temporal/event-stream.js';
 import type { PerceptionSession } from './session.js';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('PerceptionSemanticLoop');
 
 export interface SemanticLoopOptions {
   session: PerceptionSession;
@@ -42,6 +45,8 @@ export class SemanticLoop {
   private lastTickMs = 0;
   /** Whether stop() has been called. */
   private stopped = false;
+  /** Pending wake timer — tracked so stop() can clear it. */
+  private wakeTimer: ReturnType<typeof setTimeout> | null = null;
 
   private readonly escalateHandler: (payload: { from: string; regions: unknown[] }) => void;
 
@@ -69,6 +74,10 @@ export class SemanticLoop {
   stop(): void {
     this.stopped = true;
     this.session.internalEmitter.off('escalate', this.escalateHandler);
+    if (this.wakeTimer !== null) {
+      clearTimeout(this.wakeTimer);
+      this.wakeTimer = null;
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -79,7 +88,8 @@ export class SemanticLoop {
     const nowMs = Date.now();
     const elapsed = nowMs - this.lastTickMs;
     const delay = elapsed >= this.cadenceMs ? 0 : this.cadenceMs - elapsed;
-    setTimeout(() => {
+    this.wakeTimer = setTimeout(() => {
+      this.wakeTimer = null;
       if (this.stopped) return;
       if (!this.hasPendingEscalation) return;
       this.hasPendingEscalation = false;
@@ -93,45 +103,58 @@ export class SemanticLoop {
     const nowMs = Date.now();
     // Enforce cadence: if another tick ran too recently, skip.
     if (nowMs - this.lastTickMs < this.cadenceMs && this.lastTickMs !== 0) return;
-    this.lastTickMs = nowMs;
 
     this.session.recordTick('semantic', 'escalation', nowMs);
 
-    // Run the full structural + indexer pipeline.
-    const structural = await this.structuralPipeline.extractStructure(this.page);
-    const componentMap = await this.indexer.run(structural, {
-      origin: this.page.url(),
-    });
+    // I3 fix: previously the awaited body ran without a catch — a throw from
+    // extractStructure / indexer.run became an unhandled rejection AND
+    // lastTickMs was already advanced (silently gating out the next
+    // escalation). Now we only advance lastTickMs on success.
+    try {
+      const structural = await this.structuralPipeline.extractStructure(this.page);
+      const componentMap = await this.indexer.run(structural, {
+        origin: this.page.url(),
+      });
 
-    // Build a lookup from node id → structural node for bbox resolution.
-    const nodeById = new Map(structural.map((n) => [n.id, n]));
+      // Build a lookup from node id → structural node for bbox resolution.
+      const nodeById = new Map(structural.map((n) => [n.id, n]));
 
-    // Collect nodes the indexer marked as pending (unclassified).
-    const pendingRegions: Array<{ nodeId: string; bbox: { x: number; y: number; w: number; h: number } }> = [];
-    for (const [nodeId, field] of componentMap) {
-      if (field.name === null) {
-        const node = nodeById.get(nodeId);
-        const bb = node?.boundingBox ?? { x: 0, y: 0, width: 0, height: 0 };
-        pendingRegions.push({
-          nodeId,
-          bbox: { x: bb.x, y: bb.y, w: bb.width, h: bb.height },
-        });
+      // Collect nodes the indexer marked as pending (unclassified).
+      const pendingRegions: Array<{ nodeId: string; bbox: { x: number; y: number; w: number; h: number } }> = [];
+      for (const [nodeId, field] of componentMap) {
+        if (field.name === null) {
+          const node = nodeById.get(nodeId);
+          const bb = node?.boundingBox ?? { x: 0, y: 0, width: 0, height: 0 };
+          pendingRegions.push({
+            nodeId,
+            bbox: { x: bb.x, y: bb.y, w: bb.width, h: bb.height },
+          });
+        }
       }
+
+      // Tick succeeded — advance the cadence gate now (not before the await).
+      this.lastTickMs = nowMs;
+
+      if (pendingRegions.length === 0) return;
+
+      // Escalate to intent tier.
+      this.session.recordEscalation(
+        'semantic',
+        'intent',
+        'mutation-outside-animation',
+        pendingRegions,
+        nowMs,
+      );
+      this.session.internalEmitter.emit('escalate', {
+        from: 'semantic',
+        regions: pendingRegions,
+      });
+    } catch (err) {
+      logger.warn('SemanticLoop: tick failed; will retry on next escalation', {
+        error: err instanceof Error ? err.stack : String(err),
+      });
+      // lastTickMs intentionally not advanced — the next escalation that
+      // arrives can re-enter tick() without being gated out.
     }
-
-    if (pendingRegions.length === 0) return;
-
-    // Escalate to intent tier.
-    this.session.recordEscalation(
-      'semantic',
-      'intent',
-      'mutation-outside-animation',
-      pendingRegions,
-      nowMs,
-    );
-    this.session.internalEmitter.emit('escalate', {
-      from: 'semantic',
-      regions: pendingRegions,
-    });
   }
 }

--- a/src/pipelines/perception/semantic-loop.ts
+++ b/src/pipelines/perception/semantic-loop.ts
@@ -100,7 +100,7 @@ export class SemanticLoop {
     // Run the full structural + indexer pipeline.
     const structural = await this.structuralPipeline.extractStructure(this.page);
     const componentMap = await this.indexer.run(structural, {
-      origin: (this.page as any).url?.() ?? 'unknown',
+      origin: this.page.url(),
     });
 
     // Build a lookup from node id → structural node for bbox resolution.
@@ -109,7 +109,7 @@ export class SemanticLoop {
     // Collect nodes the indexer marked as pending (unclassified).
     const pendingRegions: Array<{ nodeId: string; bbox: { x: number; y: number; w: number; h: number } }> = [];
     for (const [nodeId, field] of componentMap) {
-      if (field.name === null && (field as any).status === 'pending') {
+      if (field.name === null) {
         const node = nodeById.get(nodeId);
         const bb = node?.boundingBox ?? { x: 0, y: 0, width: 0, height: 0 };
         pendingRegions.push({

--- a/src/pipelines/perception/session.ts
+++ b/src/pipelines/perception/session.ts
@@ -86,7 +86,7 @@ export class PerceptionSession {
     this.stream = options.eventStream;
   }
 
-  start(nowMs: number, deps?: SessionStartDeps): void {
+  async start(nowMs: number, deps?: SessionStartDeps): Promise<void> {
     if (this.state !== 'idle') {
       throw new Error(`PerceptionSession.start() called in state "${this.state}"`);
     }
@@ -114,7 +114,10 @@ export class PerceptionSession {
         classifyByVlm: deps.classifyByVlm,
         getScreenshot: deps.getScreenshot,
       });
-      this.frameLoop.start();
+      // Await frameLoop.start() so the page-side observer is installed before
+      // the first keyframe fires (Fix 3: prevents silent false negatives and
+      // unhandled rejections from exposeFunction errors).
+      await this.frameLoop.start();
       this.semanticLoop.start();
       this.intentLoop.start();
       deps.page.on('framenavigated', this.onPageNav);

--- a/src/pipelines/perception/session.ts
+++ b/src/pipelines/perception/session.ts
@@ -145,18 +145,38 @@ export class PerceptionSession {
     }
     this.state = 'stopped';
     this.stoppedAt = nowMs;
-    this.frameLoop?.stop();
-    this.semanticLoop?.stop();
-    this.intentLoop?.stop();
+
+    // P2-C2: make teardown fault-tolerant. Previously a throw mid-stop
+    // (frameLoop teardown, page.off after TargetClosed, etc.) left loop
+    // refs non-null and listeners attached but state already flipped to
+    // 'stopped' — bricking the session for future restarts. Run every step,
+    // collect errors, surface them aggregated at the end so the caller
+    // still sees the failure but the session is reliably torn down.
+    const errors: Array<{ label: string; err: unknown }> = [];
+    const safeRun = (label: string, fn: () => void): void => {
+      try { fn(); } catch (err) { errors.push({ label, err }); }
+    };
+
+    safeRun('frameLoop.stop',    () => this.frameLoop?.stop());
+    safeRun('semanticLoop.stop', () => this.semanticLoop?.stop());
+    safeRun('intentLoop.stop',   () => this.intentLoop?.stop());
     this.frameLoop = null;
     this.semanticLoop = null;
     this.intentLoop = null;
     if (this.page) {
-      this.page.off('framenavigated', this.onPageNav);
-      this.page.off('close', this.onPageClose);
+      const page = this.page;
+      safeRun('page.off framenavigated', () => page.off('framenavigated', this.onPageNav));
+      safeRun('page.off close',          () => page.off('close',          this.onPageClose));
       this.page = null;
     }
     this.internalEmitter.removeAllListeners();
+
+    if (errors.length > 0) {
+      const summary = errors
+        .map(({ label, err }) => `${label}: ${err instanceof Error ? err.message : String(err)}`)
+        .join('; ');
+      throw new Error(`PerceptionSession.stop() partial failure: ${summary}`);
+    }
   }
 
   isRunning(): boolean {

--- a/src/pipelines/perception/session.ts
+++ b/src/pipelines/perception/session.ts
@@ -11,9 +11,12 @@ import type { PerceptionSessionSummary } from './types.js';
 import type { FrameCapture } from '../visual/frame-capture.js';
 import type { StructuralPipeline } from '../structural/index.js';
 import type { Indexer } from '../component-index/indexer.js';
+import { createLogger } from '../../utils/logger.js';
 import { FrameLoop } from './frame-loop.js';
 import { SemanticLoop } from './semantic-loop.js';
 import { IntentLoop, type ClassifyByVlmFn } from './intent-loop.js';
+
+const logger = createLogger('PerceptionSession');
 
 const TARGET_CADENCE_MS: Record<PerceptionTier, number> = {
   frame: 16,        // not actually used — frame is keyframe-bound; surfaced for inspection
@@ -63,8 +66,18 @@ export class PerceptionSession {
   };
 
   private readonly onPageClose = (): void => {
-    if (this.isRunning()) {
-      try { this.stop(Date.now()); } catch { /* already stopped */ }
+    if (!this.isRunning()) return;
+    try {
+      this.stop(Date.now());
+    } catch (err) {
+      // I1 fix: previously silently swallowed via `catch { /* already stopped */ }`.
+      // The comment was wrong — stop() does loop teardown + page.off() calls
+      // that can throw for reasons other than re-entrancy (e.g. TargetClosed).
+      // Playwright fires `close` listeners fire-and-forget, so re-throwing
+      // would become an unhandled exception; log instead.
+      logger.error('PerceptionSession: stop() failed during onPageClose', {
+        error: err instanceof Error ? err.stack : String(err),
+      });
     }
   };
 

--- a/src/pipelines/perception/session.ts
+++ b/src/pipelines/perception/session.ts
@@ -179,7 +179,12 @@ export class PerceptionSession {
   ): void {
     const t = this.ticks[tier];
     t.count += 1;
-    if (t.lastTimestamp !== null) {
+    // I4 fix: a `navigation-reset` tick marks a discontinuity (multi-second
+    // SPA route change) — counting its interval would dominate the cadence
+    // average and make the metric useless. Still bump count + update
+    // lastTimestamp (so the next real tick measures from after the nav),
+    // but skip the intervalSum/intervalCount aggregation.
+    if (t.lastTimestamp !== null && cause !== 'navigation-reset') {
       t.intervalSum += timestamp - t.lastTimestamp;
       t.intervalCount += 1;
     }

--- a/src/pipelines/perception/session.ts
+++ b/src/pipelines/perception/session.ts
@@ -94,6 +94,7 @@ export class PerceptionSession {
   private escalationCount = 0;
   private intentResultCount = 0;
   private vlmCallCount = 0;
+  private vlmErrorCount = 0;
 
   constructor(options: PerceptionSessionOptions) {
     this.stream = options.eventStream;
@@ -239,6 +240,13 @@ export class PerceptionSession {
     });
   }
 
+  /** I2 fix: a 100%-failed session previously looked identical to a
+   *  no-escalation session because only successful VLM calls were counted.
+   *  Track errors separately so cost / health metrics are honest. */
+  recordVlmError(): void {
+    this.vlmErrorCount += 1;
+  }
+
   getSummary(): PerceptionSessionSummary {
     const now = this.state === 'running' ? Date.now() : this.stoppedAt;
     const durationMs = this.state === 'idle' ? 0 : now - this.startedAt;
@@ -269,7 +277,10 @@ export class PerceptionSession {
       anomaliesByReason,
       escalationCount: this.escalationCount,
       intentResultCount: this.intentResultCount,
-      vlmCalls: { count: this.vlmCallCount },
+      vlmCalls: {
+        count: this.vlmCallCount,
+        ...(this.vlmErrorCount > 0 ? { errorCount: this.vlmErrorCount } : {}),
+      },
     };
   }
 }

--- a/src/pipelines/perception/session.ts
+++ b/src/pipelines/perception/session.ts
@@ -1,0 +1,186 @@
+import { EventEmitter } from 'node:events';
+import { randomUUID } from 'node:crypto';
+import type {
+  AnomalyReason,
+  PerceptionTier,
+  PerceptionEscalationPayload,
+} from '../temporal/collectors/types.js';
+import type { TemporalEventStream } from '../temporal/event-stream.js';
+import type { PerceptionSessionSummary } from './types.js';
+
+const TARGET_CADENCE_MS: Record<PerceptionTier, number> = {
+  frame: 16,        // not actually used — frame is keyframe-bound; surfaced for inspection
+  semantic: 200,
+  intent: 1000,
+};
+
+const ALL_ANOMALY_REASONS: AnomalyReason[] = ['mutation-outside-animation'];
+
+interface PerceptionSessionOptions {
+  eventStream: TemporalEventStream;
+}
+
+interface TickRecord {
+  count: number;
+  lastTimestamp: number | null;
+  intervalSum: number;     // sum of intervals between consecutive ticks
+  intervalCount: number;   // number of intervals (count - 1)
+}
+
+export class PerceptionSession {
+  readonly internalEmitter = new EventEmitter();
+
+  private state: 'idle' | 'running' | 'stopped' = 'idle';
+  private startedAt = 0;
+  private stoppedAt = 0;
+  private readonly stream: TemporalEventStream;
+
+  private readonly ticks: Record<PerceptionTier, TickRecord> = {
+    frame:    { count: 0, lastTimestamp: null, intervalSum: 0, intervalCount: 0 },
+    semantic: { count: 0, lastTimestamp: null, intervalSum: 0, intervalCount: 0 },
+    intent:   { count: 0, lastTimestamp: null, intervalSum: 0, intervalCount: 0 },
+  };
+
+  private anomalyCount = 0;
+  private anomaliesByReason: Record<AnomalyReason, number> = {
+    'mutation-outside-animation': 0,
+  };
+  private escalationCount = 0;
+  private intentResultCount = 0;
+  private vlmCallCount = 0;
+
+  constructor(options: PerceptionSessionOptions) {
+    this.stream = options.eventStream;
+  }
+
+  start(nowMs: number): void {
+    if (this.state !== 'idle') {
+      throw new Error(`PerceptionSession.start() called in state "${this.state}"`);
+    }
+    this.state = 'running';
+    this.startedAt = nowMs;
+  }
+
+  stop(nowMs: number): void {
+    if (this.state !== 'running') {
+      throw new Error(`PerceptionSession.stop() called in state "${this.state}"`);
+    }
+    this.state = 'stopped';
+    this.stoppedAt = nowMs;
+  }
+
+  isRunning(): boolean {
+    return this.state === 'running';
+  }
+
+  getStartedAt(): number {
+    return this.startedAt;
+  }
+
+  /** Reset startedAt after a navigation event so the warmup gate re-applies. */
+  resetStartedAt(nowMs: number): void {
+    this.startedAt = nowMs;
+  }
+
+  recordTick(
+    tier: PerceptionTier,
+    cause: 'keyframe' | 'heartbeat' | 'escalation' | 'navigation-reset',
+    timestamp: number,
+  ): void {
+    const t = this.ticks[tier];
+    t.count += 1;
+    if (t.lastTimestamp !== null) {
+      t.intervalSum += timestamp - t.lastTimestamp;
+      t.intervalCount += 1;
+    }
+    t.lastTimestamp = timestamp;
+    this.stream.push({
+      id: randomUUID(),
+      type: 'perception-tick',
+      timestamp,
+      payload: { tier, cause },
+    });
+  }
+
+  recordAnomaly(
+    tier: PerceptionTier,
+    reason: AnomalyReason,
+    detail: { mutationCount: number; targetNodeIds: string[] },
+    timestamp: number,
+  ): void {
+    this.anomalyCount += 1;
+    this.anomaliesByReason[reason] += 1;
+    this.stream.push({
+      id: randomUUID(),
+      type: 'perception-anomaly',
+      timestamp,
+      payload: { tier, reason, detail },
+    });
+  }
+
+  recordEscalation(
+    from: PerceptionTier,
+    to: PerceptionTier,
+    reason: AnomalyReason,
+    regions: PerceptionEscalationPayload['regions'],
+    timestamp: number,
+  ): void {
+    this.escalationCount += 1;
+    this.stream.push({
+      id: randomUUID(),
+      type: 'perception-escalation',
+      timestamp,
+      payload: { from, to, reason, regions },
+    });
+  }
+
+  recordIntentResult(
+    region: { nodeId: string; bbox: { x: number; y: number; w: number; h: number } },
+    classification: string,
+    durationMs: number,
+    timestamp: number,
+  ): void {
+    this.intentResultCount += 1;
+    this.vlmCallCount += 1;
+    this.stream.push({
+      id: randomUUID(),
+      type: 'perception-intent-result',
+      timestamp,
+      payload: { region, classification, classificationSource: 'vlm', durationMs },
+    });
+  }
+
+  getSummary(): PerceptionSessionSummary {
+    const now = this.state === 'running' ? Date.now() : this.stoppedAt;
+    const durationMs = this.state === 'idle' ? 0 : now - this.startedAt;
+
+    const averageCadenceMs: Record<PerceptionTier, number | null> = {
+      frame:    this.ticks.frame.intervalCount > 0    ? this.ticks.frame.intervalSum    / this.ticks.frame.intervalCount    : null,
+      semantic: this.ticks.semantic.intervalCount > 0 ? this.ticks.semantic.intervalSum / this.ticks.semantic.intervalCount : null,
+      intent:   this.ticks.intent.intervalCount > 0   ? this.ticks.intent.intervalSum   / this.ticks.intent.intervalCount   : null,
+    };
+
+    // Initialize anomaliesByReason buckets with zeros even if never fired
+    const anomaliesByReason = {} as Record<AnomalyReason, number>;
+    for (const r of ALL_ANOMALY_REASONS) {
+      anomaliesByReason[r] = this.anomaliesByReason[r] ?? 0;
+    }
+
+    return {
+      startedAt: this.startedAt,
+      durationMs,
+      tickCounts: {
+        frame:    this.ticks.frame.count,
+        semantic: this.ticks.semantic.count,
+        intent:   this.ticks.intent.count,
+      },
+      averageCadenceMs,
+      targetCadenceMs: TARGET_CADENCE_MS,
+      anomalyCount: this.anomalyCount,
+      anomaliesByReason,
+      escalationCount: this.escalationCount,
+      intentResultCount: this.intentResultCount,
+      vlmCalls: { count: this.vlmCallCount },
+    };
+  }
+}

--- a/src/pipelines/perception/session.ts
+++ b/src/pipelines/perception/session.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { randomUUID } from 'node:crypto';
+import type { Page } from 'playwright';
 import type {
   AnomalyReason,
   PerceptionTier,
@@ -7,6 +8,12 @@ import type {
 } from '../temporal/collectors/types.js';
 import type { TemporalEventStream } from '../temporal/event-stream.js';
 import type { PerceptionSessionSummary } from './types.js';
+import type { FrameCapture } from '../visual/frame-capture.js';
+import type { StructuralPipeline } from '../structural/index.js';
+import type { Indexer } from '../component-index/indexer.js';
+import { FrameLoop } from './frame-loop.js';
+import { SemanticLoop } from './semantic-loop.js';
+import { IntentLoop, type ClassifyByVlmFn } from './intent-loop.js';
 
 const TARGET_CADENCE_MS: Record<PerceptionTier, number> = {
   frame: 16,        // not actually used — frame is keyframe-bound; surfaced for inspection
@@ -18,6 +25,15 @@ const ALL_ANOMALY_REASONS: AnomalyReason[] = ['mutation-outside-animation'];
 
 interface PerceptionSessionOptions {
   eventStream: TemporalEventStream;
+}
+
+export interface SessionStartDeps {
+  page: Page;
+  frameCapture: FrameCapture;
+  indexer: Indexer;
+  structuralPipeline: StructuralPipeline;
+  classifyByVlm: ClassifyByVlmFn;
+  getScreenshot: () => Promise<Buffer | null>;
 }
 
 interface TickRecord {
@@ -34,6 +50,23 @@ export class PerceptionSession {
   private startedAt = 0;
   private stoppedAt = 0;
   private readonly stream: TemporalEventStream;
+
+  private frameLoop: FrameLoop | null = null;
+  private semanticLoop: SemanticLoop | null = null;
+  private intentLoop: IntentLoop | null = null;
+  private page: Page | null = null;
+
+  private readonly onPageNav = (): void => {
+    const now = Date.now();
+    this.resetStartedAt(now);
+    this.recordTick('frame', 'navigation-reset', now);
+  };
+
+  private readonly onPageClose = (): void => {
+    if (this.isRunning()) {
+      try { this.stop(Date.now()); } catch { /* already stopped */ }
+    }
+  };
 
   private readonly ticks: Record<PerceptionTier, TickRecord> = {
     frame:    { count: 0, lastTimestamp: null, intervalSum: 0, intervalCount: 0 },
@@ -53,12 +86,40 @@ export class PerceptionSession {
     this.stream = options.eventStream;
   }
 
-  start(nowMs: number): void {
+  start(nowMs: number, deps?: SessionStartDeps): void {
     if (this.state !== 'idle') {
       throw new Error(`PerceptionSession.start() called in state "${this.state}"`);
     }
     this.state = 'running';
     this.startedAt = nowMs;
+
+    if (deps) {
+      this.page = deps.page;
+      this.frameLoop = new FrameLoop({
+        session: this,
+        frameCapture: deps.frameCapture,
+        eventStream: this.stream,
+        page: deps.page,
+      });
+      this.semanticLoop = new SemanticLoop({
+        session: this,
+        eventStream: this.stream,
+        indexer: deps.indexer,
+        structuralPipeline: deps.structuralPipeline,
+        page: deps.page,
+      });
+      this.intentLoop = new IntentLoop({
+        session: this,
+        eventStream: this.stream,
+        classifyByVlm: deps.classifyByVlm,
+        getScreenshot: deps.getScreenshot,
+      });
+      this.frameLoop.start();
+      this.semanticLoop.start();
+      this.intentLoop.start();
+      deps.page.on('framenavigated', this.onPageNav);
+      deps.page.on('close', this.onPageClose);
+    }
   }
 
   stop(nowMs: number): void {
@@ -67,6 +128,18 @@ export class PerceptionSession {
     }
     this.state = 'stopped';
     this.stoppedAt = nowMs;
+    this.frameLoop?.stop();
+    this.semanticLoop?.stop();
+    this.intentLoop?.stop();
+    this.frameLoop = null;
+    this.semanticLoop = null;
+    this.intentLoop = null;
+    if (this.page) {
+      this.page.off('framenavigated', this.onPageNav);
+      this.page.off('close', this.onPageClose);
+      this.page = null;
+    }
+    this.internalEmitter.removeAllListeners();
   }
 
   isRunning(): boolean {

--- a/src/pipelines/perception/types.ts
+++ b/src/pipelines/perception/types.ts
@@ -10,5 +10,5 @@ export interface PerceptionSessionSummary {
   anomaliesByReason: Record<AnomalyReason, number>;
   escalationCount: number;
   intentResultCount: number;
-  vlmCalls: { count: number; estimatedDollars?: number };
+  vlmCalls: { count: number; errorCount?: number; estimatedDollars?: number };
 }

--- a/src/pipelines/perception/types.ts
+++ b/src/pipelines/perception/types.ts
@@ -1,0 +1,14 @@
+import type { PerceptionTier, AnomalyReason } from '../temporal/collectors/types.js';
+
+export interface PerceptionSessionSummary {
+  startedAt: number;                  // stream-relative ms at session start
+  durationMs: number;                 // wall-clock elapsed since startedAt
+  tickCounts: Record<PerceptionTier, number>;
+  averageCadenceMs: Record<PerceptionTier, number | null>;  // null if loop never ticked
+  targetCadenceMs: Record<PerceptionTier, number>;          // declared target
+  anomalyCount: number;
+  anomaliesByReason: Record<AnomalyReason, number>;
+  escalationCount: number;
+  intentResultCount: number;
+  vlmCalls: { count: number; estimatedDollars?: number };
+}

--- a/src/pipelines/temporal/collectors/types.ts
+++ b/src/pipelines/temporal/collectors/types.ts
@@ -12,7 +12,11 @@ export type EventType =
   | 'phash-change'
   | 'optical-flow-raw'
   | 'optical-flow-region'
-  | 'optical-flow-motion';
+  | 'optical-flow-motion'
+  | 'perception-tick'
+  | 'perception-anomaly'
+  | 'perception-escalation'
+  | 'perception-intent-result';
 
 export interface InputPayload {
   kind: 'click' | 'keydown';
@@ -139,6 +143,41 @@ export interface OpticalFlowMotionPayload {
   confidence: number;
 }
 
+export type PerceptionTier = 'frame' | 'semantic' | 'intent';
+
+export type AnomalyReason = 'mutation-outside-animation';
+
+export interface PerceptionTickPayload {
+  tier: PerceptionTier;
+  cause: 'keyframe' | 'heartbeat' | 'escalation' | 'navigation-reset';
+}
+
+export interface PerceptionAnomalyPayload {
+  tier: PerceptionTier;
+  reason: AnomalyReason;
+  detail: {
+    mutationCount: number;
+    targetNodeIds: string[];
+  };
+}
+
+export interface PerceptionEscalationPayload {
+  from: PerceptionTier;
+  to: PerceptionTier;
+  reason: AnomalyReason;
+  regions: Array<{
+    nodeId: string;
+    bbox: { x: number; y: number; w: number; h: number };
+  }>;
+}
+
+export interface PerceptionIntentResultPayload {
+  region: { nodeId: string; bbox: { x: number; y: number; w: number; h: number } };
+  classification: string;
+  classificationSource: 'vlm';
+  durationMs: number;
+}
+
 export type PayloadFor<T extends EventType> =
   T extends 'input'             ? InputPayload :
   T extends 'mutation'          ? MutationPayload :
@@ -151,6 +190,10 @@ export type PayloadFor<T extends EventType> =
   T extends 'optical-flow-raw'    ? OpticalFlowRawPayload :
   T extends 'optical-flow-region' ? OpticalFlowRegionPayload :
   T extends 'optical-flow-motion' ? OpticalFlowMotionPayload :
+  T extends 'perception-tick'           ? PerceptionTickPayload :
+  T extends 'perception-anomaly'        ? PerceptionAnomalyPayload :
+  T extends 'perception-escalation'     ? PerceptionEscalationPayload :
+  T extends 'perception-intent-result'  ? PerceptionIntentResultPayload :
   never;
 
 export interface TimelineEvent<T extends EventType = EventType> {

--- a/src/pipelines/temporal/event-stream.ts
+++ b/src/pipelines/temporal/event-stream.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import type { Page } from 'playwright';
 import type { TimelineEvent, EventType } from './collectors/types.js';
 import type { Collector } from './collectors/types.js';
@@ -30,7 +31,7 @@ const buildNormalizer = (anchors: ClockAnchors): ClockNormalizer => ({
   fromCdpMonotonicSeconds: (secs) => (secs * 1000) - anchors.pagePerformanceAnchorMs,
 });
 
-export class TemporalEventStream {
+export class TemporalEventStream extends EventEmitter {
   private buffer: TimelineEvent[] = [];
   private readonly capacity: number;
   private readonly clearOnNavigate: boolean;
@@ -40,6 +41,7 @@ export class TemporalEventStream {
   private framenavigatedHandler: ((frame: any) => Promise<void>) | undefined;
 
   constructor(options: TemporalEventStreamOptions = {}) {
+    super();
     this.capacity = options.capacity ?? 10000;
     this.clearOnNavigate = options.clearOnNavigate ?? true;
   }
@@ -118,6 +120,8 @@ export class TemporalEventStream {
     if (this.buffer.length > this.capacity) {
       this.buffer.shift();
     }
+    // Emit so subscribers (FrameLoop, SemanticLoop, etc.) can react in real time.
+    this.emit('event', event);
   }
 
   getEvents(filter: GetEventsFilter = {}): TimelineEvent[] {

--- a/tests/integration/perception/fixtures/mutation-trigger.html
+++ b/tests/integration/perception/fixtures/mutation-trigger.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head><title>Mutation Trigger</title>
+<style>
+  body { font-family: system-ui; padding: 24px; }
+  #target { display: block; width: 200px; height: 80px; padding: 16px; border: 1px solid #ccc; background: #eef; }
+  button { padding: 8px 16px; margin-top: 12px; cursor: pointer; }
+</style>
+</head>
+<body>
+  <div id="target">
+    <span id="text">original text</span>
+  </div>
+  <button id="trigger">Trigger mutation</button>
+  <script>
+    document.getElementById('trigger').addEventListener('click', () => {
+      // Pure JS mutation — no CSS animation.
+      setTimeout(() => {
+        document.getElementById('text').textContent = 'changed';
+      }, 50);
+    });
+  </script>
+</body>
+</html>

--- a/tests/integration/perception/perception-e2e.test.ts
+++ b/tests/integration/perception/perception-e2e.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { chromium, type Browser, type Page } from 'playwright';
+import { readFile, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { EventEmitter } from 'node:events';
+import { StructuralPipeline } from '../../../src/pipelines/structural/index.js';
+import { ComponentIndexStore } from '../../../src/pipelines/component-index/store.js';
+import { ClassificationQueue } from '../../../src/pipelines/component-index/queue.js';
+import { Matcher } from '../../../src/pipelines/component-index/matcher.js';
+import { Indexer } from '../../../src/pipelines/component-index/indexer.js';
+import { TemporalEventStream } from '../../../src/pipelines/temporal/event-stream.js';
+import { MutationCollector, AnimationCollector } from '../../../src/pipelines/temporal/collectors/index.js';
+import { PerceptionSession } from '../../../src/pipelines/perception/session.js';
+
+const FIXTURE = resolve(fileURLToPath(import.meta.url), '..', 'fixtures', 'mutation-trigger.html');
+
+class FakeFrameCapture extends EventEmitter {
+  start = vi.fn(async () => {});
+  stop = vi.fn(async () => {});
+  emitFakeKeyframe(timestamp: number) {
+    this.emit('keyframe', { frame: Buffer.from([0x89, 0x50]), timestamp });
+  }
+}
+
+describe('Perception loops — end-to-end (Playwright)', () => {
+  let browser: Browser;
+  let page: Page;
+  let tmp: string;
+
+  beforeAll(async () => { browser = await chromium.launch(); });
+  afterAll(async () => { await browser.close(); });
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'uipe-perception-e2e-'));
+    const html = await readFile(FIXTURE, 'utf8');
+    page = await browser.newPage({ viewport: { width: 800, height: 600 } });
+    await page.setContent(html, { waitUntil: 'load' });
+  });
+
+  afterEach(async () => {
+    await page.close();
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('full chain: mutation → frame anomaly → semantic escalation → intent VLM', async () => {
+    const stream = new TemporalEventStream();
+    const mutationCollector = new MutationCollector();
+    const animationCollector = new AnimationCollector();
+    await stream.attach(page, [mutationCollector, animationCollector]);
+
+    const structural = new StructuralPipeline();
+    const store = new ComponentIndexStore({ baseDir: tmp });
+    const queue = new ClassificationQueue();
+    const matcher = new Matcher({ store, queue });
+    const indexer = new Indexer({ matcher });
+
+    const stubVlm = vi.fn(async () => 'TestComponent');
+    const frameCapture = new FakeFrameCapture();
+    const session = new PerceptionSession({ eventStream: stream });
+    session.start(Date.now() - 1000, {  // start 1s in the past so warmup is past
+      page,
+      frameCapture: frameCapture as any,
+      indexer,
+      structuralPipeline: structural,
+      classifyByVlm: stubVlm,
+      getScreenshot: async () => page.screenshot({ type: 'png' }),
+    });
+
+    // Wait past the warmup window (500ms default)
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Click the button → after 50ms a text mutation fires (no CSS animation).
+    // We emit the keyframe shortly after the mutation arrives so it's still
+    // within the 200ms lookback window.
+    await page.click('#trigger');
+    // Wait for the mutation to fire (button handler uses setTimeout 50ms)
+    await new Promise((r) => setTimeout(r, 100));
+    // Emit keyframe immediately — mutation is <100ms old, well within lookbackMs=200
+    frameCapture.emitFakeKeyframe(Date.now());
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Stop perception
+    session.stop(Date.now());
+    const summary = session.getSummary();
+
+    expect(summary.anomalyCount).toBeGreaterThanOrEqual(1);
+    expect(summary.anomaliesByReason['mutation-outside-animation']).toBeGreaterThanOrEqual(1);
+    expect(summary.escalationCount).toBeGreaterThanOrEqual(1);
+    // Intent only fires if the semantic loop flagged a pending component.
+    // This depends on the fixture's text node being a recognized signature
+    // or not; we don't assert intent strictly here — just verify the chain.
+  }, 30_000);
+
+  it('does not fire anomaly when mutation happens during an active animation', async () => {
+    const stream = new TemporalEventStream();
+    const mutationCollector = new MutationCollector();
+    const animationCollector = new AnimationCollector();
+    // Attach collectors first so AnimationCollector's CDP session is live.
+    await stream.attach(page, [mutationCollector, animationCollector]);
+
+    const structural = new StructuralPipeline();
+    const store = new ComponentIndexStore({ baseDir: tmp });
+    const queue = new ClassificationQueue();
+    const matcher = new Matcher({ store, queue });
+    const indexer = new Indexer({ matcher });
+
+    const stubVlm = vi.fn(async () => 'X');
+    const frameCapture = new FakeFrameCapture();
+    const session = new PerceptionSession({ eventStream: stream });
+    // Start the session BEFORE the animation so FrameLoop is subscribed to
+    // stream events and will track the animation-start event in activeAnimations.
+    session.start(Date.now() - 1000, {
+      page,
+      frameCapture: frameCapture as any,
+      indexer,
+      structuralPipeline: structural,
+      classifyByVlm: stubVlm,
+      getScreenshot: async () => page.screenshot({ type: 'png' }),
+    });
+
+    // Wait for FrameLoop to finish installing its page-side MutationObserver
+    // (start() is async internally but returns void — give it a tick).
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Start a long animation — AnimationCollector pushes animation-start,
+    // FrameLoop's stream subscription adds it to activeAnimations.
+    await page.evaluate(() => {
+      const target = document.getElementById('target')!;
+      target.animate(
+        [{ opacity: 1 }, { opacity: 0.5 }, { opacity: 1 }],
+        { duration: 2000, iterations: 1 },
+      );
+    });
+    // Pause for Animation.animationStarted CDP event to be processed by AnimationCollector
+    // and for FrameLoop's handleStreamEvent to update activeAnimations.
+    await new Promise((r) => setTimeout(r, 150));
+
+    await page.click('#trigger');
+    // Wait for the mutation (50ms setTimeout in the fixture handler)
+    await new Promise((r) => setTimeout(r, 100));
+    // Emit keyframe — animation is still active (2s duration), mutation present
+    frameCapture.emitFakeKeyframe(Date.now());
+    await new Promise((r) => setTimeout(r, 200));
+
+    session.stop(Date.now());
+    const summary = session.getSummary();
+    expect(summary.anomalyCount).toBe(0);
+  }, 30_000);
+});

--- a/tests/unit/mcp/perception.test.ts
+++ b/tests/unit/mcp/perception.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createPerceptionState,
+  makeStartPerceptionTool,
+  makeStopPerceptionTool,
+  makeGetPerceptionSessionTool,
+} from '../../../src/mcp/tools/perception.js';
+
+function mkDeps() {
+  const session = {
+    isRunning: vi.fn(() => false),
+    start: vi.fn(),
+    stop: vi.fn(),
+    getSummary: vi.fn(() => ({
+      startedAt: 100,
+      durationMs: 0,
+      tickCounts: { frame: 0, semantic: 0, intent: 0 },
+    } as any)),
+    getStartedAt: vi.fn(() => 100),
+  };
+  const ensureLaunched = vi.fn(async () => {});
+  const ensureWatchStarted = vi.fn(async () => {});
+  const getPage = vi.fn(() => ({ url: () => 'http://x', on: vi.fn(), off: vi.fn() } as any));
+  const getDeps = vi.fn(() => ({
+    page: getPage(),
+    frameCapture: {} as any,
+    indexer: {} as any,
+    structuralPipeline: {} as any,
+    classifyByVlm: vi.fn() as any,
+    getScreenshot: vi.fn() as any,
+  }));
+  return { session, ensureLaunched, ensureWatchStarted, getPage, getDeps };
+}
+
+describe('start_perception', () => {
+  it('starts a session and reports startedAt', async () => {
+    const deps = mkDeps();
+    const state = createPerceptionState();
+    state.createSession = vi.fn(() => deps.session as any);
+    const tool = makeStartPerceptionTool({
+      state,
+      ensureLaunched: deps.ensureLaunched,
+      ensureWatchStarted: deps.ensureWatchStarted,
+      getSessionDeps: deps.getDeps,
+    });
+    const result = await tool.handler({});
+    expect(result).toEqual({ status: 'started', startedAt: expect.any(Number) });
+    expect(deps.ensureWatchStarted).toHaveBeenCalled();
+    expect(deps.session.start).toHaveBeenCalled();
+  });
+
+  it('returns already-running if session is active', async () => {
+    const deps = mkDeps();
+    const state = createPerceptionState();
+    deps.session.isRunning = vi.fn(() => true);
+    state.currentSession = deps.session as any;
+    const tool = makeStartPerceptionTool({
+      state,
+      ensureLaunched: deps.ensureLaunched,
+      ensureWatchStarted: deps.ensureWatchStarted,
+      getSessionDeps: deps.getDeps,
+    });
+    const result = await tool.handler({});
+    expect(result).toEqual({ status: 'already-running', startedAt: 100 });
+    expect(deps.ensureWatchStarted).not.toHaveBeenCalled();
+  });
+});
+
+describe('stop_perception', () => {
+  it('stops the session, stores summary, clears currentSession', async () => {
+    const deps = mkDeps();
+    deps.session.isRunning = vi.fn(() => true);
+    const state = createPerceptionState();
+    state.currentSession = deps.session as any;
+    const tool = makeStopPerceptionTool({ state });
+    const result = await tool.handler({});
+    expect(deps.session.stop).toHaveBeenCalled();
+    expect(state.currentSession).toBeNull();
+    expect((result as any).startedAt).toBe(100);
+  });
+
+  it('returns lastSummary if no session is running', async () => {
+    const state = createPerceptionState();
+    state.lastSummary = { startedAt: 50, durationMs: 200 } as any;
+    const tool = makeStopPerceptionTool({ state });
+    const result = await tool.handler({});
+    expect((result as any).startedAt).toBe(50);
+  });
+
+  it('returns error if no session and no last summary', async () => {
+    const state = createPerceptionState();
+    const tool = makeStopPerceptionTool({ state });
+    const result = await tool.handler({});
+    expect((result as any).error).toMatch(/no session/i);
+  });
+});
+
+describe('get_perception_session', () => {
+  it('returns the running summary without stopping', async () => {
+    const deps = mkDeps();
+    deps.session.isRunning = vi.fn(() => true);
+    const state = createPerceptionState();
+    state.currentSession = deps.session as any;
+    const tool = makeGetPerceptionSessionTool({ state });
+    const result = await tool.handler({});
+    expect((result as any).startedAt).toBe(100);
+    // session must NOT be stopped
+    expect(deps.session.stop).not.toHaveBeenCalled();
+  });
+
+  it('falls back to lastSummary when no session is running', async () => {
+    const state = createPerceptionState();
+    state.lastSummary = { startedAt: 33 } as any;
+    const tool = makeGetPerceptionSessionTool({ state });
+    const result = await tool.handler({});
+    expect((result as any).startedAt).toBe(33);
+  });
+
+  it('returns error when no session and no last summary', async () => {
+    const state = createPerceptionState();
+    const tool = makeGetPerceptionSessionTool({ state });
+    const result = await tool.handler({});
+    expect((result as any).error).toMatch(/no session/i);
+  });
+});

--- a/tests/unit/mcp/perception.test.ts
+++ b/tests/unit/mcp/perception.test.ts
@@ -42,11 +42,46 @@ describe('start_perception', () => {
       ensureLaunched: deps.ensureLaunched,
       ensureWatchStarted: deps.ensureWatchStarted,
       getSessionDeps: deps.getDeps,
+      getEventStream: () => ({} as any),
     });
     const result = await tool.handler({});
     expect(result).toEqual({ status: 'started', startedAt: expect.any(Number) });
     expect(deps.ensureWatchStarted).toHaveBeenCalled();
     expect(deps.session.start).toHaveBeenCalled();
+  });
+
+  it('throws a clear error when getEventStream is missing and does not mutate state (C4 fix)', async () => {
+    const deps = mkDeps();
+    const state = createPerceptionState();
+    const createSpy = vi.fn(() => deps.session as any);
+    state.createSession = createSpy;
+    const tool = makeStartPerceptionTool({
+      state,
+      ensureLaunched: deps.ensureLaunched,
+      ensureWatchStarted: deps.ensureWatchStarted,
+      getSessionDeps: deps.getDeps,
+      // intentionally no getEventStream
+    });
+    await expect(tool.handler({})).rejects.toThrow(/event ?stream/i);
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(state.currentSession).toBeNull();
+  });
+
+  it('throws a clear error when getEventStream returns undefined (C4 fix)', async () => {
+    const deps = mkDeps();
+    const state = createPerceptionState();
+    const createSpy = vi.fn(() => deps.session as any);
+    state.createSession = createSpy;
+    const tool = makeStartPerceptionTool({
+      state,
+      ensureLaunched: deps.ensureLaunched,
+      ensureWatchStarted: deps.ensureWatchStarted,
+      getSessionDeps: deps.getDeps,
+      getEventStream: () => undefined as any,
+    });
+    await expect(tool.handler({})).rejects.toThrow(/event ?stream/i);
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(state.currentSession).toBeNull();
   });
 
   it('returns already-running if session is active', async () => {

--- a/tests/unit/mcp/tools.test.ts
+++ b/tests/unit/mcp/tools.test.ts
@@ -5,8 +5,8 @@ import { makeGetTimelineTool } from '../../../src/mcp/tools/get-timeline.js';
 import type { InputPayload, MutationPayload } from '../../../src/pipelines/temporal/collectors/types.js';
 
 describe('MCP Tools', () => {
-  it('TOOL_NAMES has exactly 14 entries', () => {
-    expect(TOOL_NAMES).toHaveLength(14);
+  it('TOOL_NAMES has exactly 17 entries', () => {
+    expect(TOOL_NAMES).toHaveLength(17);
   });
 
   it('contains all 7 original tools', () => {
@@ -45,6 +45,18 @@ describe('MCP Tools', () => {
 
   it('contains get_component_index tool', () => {
     expect(TOOL_NAMES).toContain('get_component_index');
+  });
+
+  it('contains start_perception tool', () => {
+    expect(TOOL_NAMES).toContain('start_perception');
+  });
+
+  it('contains stop_perception tool', () => {
+    expect(TOOL_NAMES).toContain('stop_perception');
+  });
+
+  it('contains get_perception_session tool', () => {
+    expect(TOOL_NAMES).toContain('get_perception_session');
   });
 });
 

--- a/tests/unit/pipelines/perception/anomaly/mutation-outside-animation.test.ts
+++ b/tests/unit/pipelines/perception/anomaly/mutation-outside-animation.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import {
+  detectMutationOutsideAnimation,
+  type MutationRecord,
+} from '../../../../../src/pipelines/perception/anomaly/mutation-outside-animation.js';
+
+function mkMutation(timestamp: number, targetNodeId: string): MutationRecord {
+  return { timestamp, targetNodeId };
+}
+
+const DEFAULTS = { lookbackMs: 200, coalesceWindowMs: 100, warmupMs: 500 };
+
+describe('detectMutationOutsideAnimation', () => {
+  it('returns null during warmup window', () => {
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [mkMutation(100, 'a')],
+      activeAnimations: new Set(),
+      nowMs: 400,            // 400 - 0 = 400 < 500ms warmup
+      sessionStartMs: 0,
+    }, DEFAULTS);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when any animation is active', () => {
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [mkMutation(900, 'a')],
+      activeAnimations: new Set(['anim-1']),
+      nowMs: 1000,
+      sessionStartMs: 0,
+    }, DEFAULTS);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no mutations', () => {
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [],
+      activeAnimations: new Set(),
+      nowMs: 1000,
+      sessionStartMs: 0,
+    }, DEFAULTS);
+    expect(result).toBeNull();
+  });
+
+  it('returns result when past warmup + no animation + has mutations', () => {
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [mkMutation(950, 'a'), mkMutation(960, 'b')],
+      activeAnimations: new Set(),
+      nowMs: 1000,
+      sessionStartMs: 0,
+    }, DEFAULTS);
+    expect(result).toEqual({
+      mutationCount: 2,
+      targetNodeIds: ['a', 'b'],
+    });
+  });
+
+  it('coalesces mutations within the coalesce window into one burst', () => {
+    // Three mutations at 900, 950, 990 — gaps 50ms and 40ms, both ≤ 100ms coalesce
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [
+        mkMutation(900, 'a'),
+        mkMutation(950, 'b'),
+        mkMutation(990, 'c'),
+      ],
+      activeAnimations: new Set(),
+      nowMs: 1000,
+      sessionStartMs: 0,
+    }, DEFAULTS);
+    expect(result).toEqual({
+      mutationCount: 3,
+      targetNodeIds: ['a', 'b', 'c'],
+    });
+  });
+
+  it('takes only the latest burst when multiple non-overlapping bursts exist', () => {
+    // Burst A: 600-650 (older). Burst B: 950-990 (latest). Gap = 300ms > coalesce.
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [
+        mkMutation(600, 'old1'),
+        mkMutation(650, 'old2'),
+        mkMutation(950, 'new1'),
+        mkMutation(990, 'new2'),
+      ],
+      activeAnimations: new Set(),
+      nowMs: 1000,
+      sessionStartMs: 0,
+    }, DEFAULTS);
+    expect(result).toEqual({
+      mutationCount: 2,
+      targetNodeIds: ['new1', 'new2'],
+    });
+  });
+
+  it('deduplicates target node IDs', () => {
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [
+        mkMutation(900, 'a'),
+        mkMutation(920, 'a'),     // same node mutated twice
+        mkMutation(950, 'b'),
+      ],
+      activeAnimations: new Set(),
+      nowMs: 1000,
+      sessionStartMs: 0,
+    }, DEFAULTS);
+    expect(result?.targetNodeIds).toEqual(['a', 'b']);
+    // mutationCount counts the events; targetNodeIds is deduped
+    expect(result?.mutationCount).toBe(3);
+  });
+
+  it('treats a single mutation as a one-event burst', () => {
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [mkMutation(950, 'a')],
+      activeAnimations: new Set(),
+      nowMs: 1000,
+      sessionStartMs: 0,
+    }, DEFAULTS);
+    expect(result).toEqual({ mutationCount: 1, targetNodeIds: ['a'] });
+  });
+
+  it('uses provided config over defaults', () => {
+    // Override warmup to 0 → no suppression
+    const result = detectMutationOutsideAnimation({
+      recentMutations: [mkMutation(100, 'a')],
+      activeAnimations: new Set(),
+      nowMs: 200,
+      sessionStartMs: 0,
+    }, { lookbackMs: 200, coalesceWindowMs: 100, warmupMs: 0 });
+    expect(result).toEqual({ mutationCount: 1, targetNodeIds: ['a'] });
+  });
+});

--- a/tests/unit/pipelines/perception/frame-loop.test.ts
+++ b/tests/unit/pipelines/perception/frame-loop.test.ts
@@ -308,6 +308,29 @@ describe('FrameLoop page-side observer', () => {
     loop2.stop();
   });
 
+  it('stopped flag prevents in-flight handler callbacks from polluting summary after stop() (C2 fix)', async () => {
+    // Simulates the race: a keyframe or stream-event listener is invoked
+    // *after* stop() runs (e.g. a re-entrant call from inside an event
+    // emission, or a deferred dispatch from a future FrameCapture
+    // implementation that batches via microtask). Sister loops semantic +
+    // intent both have a `running`/`stopped` flag; FrameLoop should too.
+    const { session, loop, stream } = setup({ warmupMs: 0 });
+    await session.start(0);
+    await loop.start();
+    loop.stop();
+
+    // Capture the original listener and invoke it directly — bypassing the
+    // unsubscribe — to model the race.
+    const onKeyframe = (loop as any).onKeyframe as (kf: KeyframeEvent) => void;
+    expect(typeof onKeyframe).toBe('function');
+    onKeyframe({ frame: Buffer.alloc(0), timestamp: 100, trigger: 'significant_diff' });
+
+    const ticks = stream.push.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.type === 'perception-tick');
+    expect(ticks).toHaveLength(0);
+  });
+
   it('framenavigated reinstall errors are caught and logged, not unhandled rejections (C3 fix)', async () => {
     const { session, page, loop } = setupWithPage({ warmupMs: 0 });
     await session.start(0);

--- a/tests/unit/pipelines/perception/frame-loop.test.ts
+++ b/tests/unit/pipelines/perception/frame-loop.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { randomUUID } from 'node:crypto';
+import { FrameLoop } from '../../../../src/pipelines/perception/frame-loop.js';
+import { PerceptionSession } from '../../../../src/pipelines/perception/session.js';
+import type { TemporalEventStream } from '../../../../src/pipelines/temporal/event-stream.js';
+import type { TimelineEvent } from '../../../../src/pipelines/temporal/collectors/types.js';
+import type { KeyframeEvent } from '../../../../src/types/temporal.js';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeFrameCapture extends EventEmitter {
+  emitKeyframe(timestamp: number, frame = Buffer.from([0x89, 0x50])): void {
+    const kf: KeyframeEvent = { frame, timestamp, trigger: 'significant_diff' };
+    this.emit('keyframe', kf);
+  }
+}
+
+/**
+ * FakeEventStream extends EventEmitter so that calling `push()` emits the
+ * 'event' signal — matching the real TemporalEventStream's behaviour after
+ * adding EventEmitter support in Task 4.
+ */
+class FakeEventStream extends EventEmitter {
+  push = vi.fn((event: TimelineEvent) => {
+    // Mirror real stream: emit so FrameLoop can subscribe.
+    this.emit('event', event);
+  });
+
+  /** Convenience: emit a timeline event as if a collector pushed it.
+   *  Payload is typed as `unknown` here to avoid complex conditional-type
+   *  inference in tests; the real stream is strongly typed. */
+  pushEvent(type: TimelineEvent['type'], payload: unknown, timestamp = 100): void {
+    const event = { id: randomUUID(), type, timestamp, payload } as TimelineEvent;
+    this.push(event);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup helper
+// ---------------------------------------------------------------------------
+
+function setup(config?: { lookbackMs?: number; coalesceWindowMs?: number; warmupMs?: number }) {
+  const stream = new FakeEventStream();
+  const session = new PerceptionSession({
+    eventStream: stream as unknown as TemporalEventStream,
+  });
+  const frameCapture = new FakeFrameCapture();
+  const loop = new FrameLoop({
+    session,
+    frameCapture: frameCapture as any,
+    eventStream: stream as unknown as TemporalEventStream,
+    // no `page` — page-side observer not installed in unit tests
+    config,
+  });
+  return { stream, session, frameCapture, loop };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('FrameLoop', () => {
+  it('emits perception-tick { tier: frame, cause: keyframe } on each keyframe', async () => {
+    const { session, frameCapture, loop, stream } = setup({ warmupMs: 0 });
+    session.start(0);
+    await loop.start();
+
+    frameCapture.emitKeyframe(50);
+
+    const ticks = stream.push.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.type === 'perception-tick');
+    expect(ticks).toHaveLength(1);
+    expect(ticks[0].payload).toMatchObject({ tier: 'frame', cause: 'keyframe' });
+  });
+
+  it('tracks animation-start/end and suppresses anomaly while animation is active', async () => {
+    const { session, frameCapture, loop, stream } = setup({ warmupMs: 0 });
+    session.start(0);
+    await loop.start();
+
+    // Start animation, add a mutation, fire keyframe — no anomaly expected.
+    stream.pushEvent('animation-start', { animationId: 'a-1', duration: 300 }, 50);
+    loop.addMutationForTest(80, 'node-x');
+    frameCapture.emitKeyframe(100);
+
+    const anomalies = stream.push.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.type === 'perception-anomaly');
+    expect(anomalies).toHaveLength(0);
+
+    // End animation; new mutation now triggers anomaly.
+    stream.pushEvent('animation-end', { animationId: 'a-1', reason: 'completed' }, 200);
+    loop.addMutationForTest(220, 'node-y');
+    frameCapture.emitKeyframe(240);
+
+    const anomalies2 = stream.push.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.type === 'perception-anomaly');
+    expect(anomalies2).toHaveLength(1);
+  });
+
+  it('emits perception-anomaly and perception-escalation when detector fires', async () => {
+    const { session, frameCapture, loop, stream } = setup({ warmupMs: 0 });
+    session.start(0);
+    await loop.start();
+
+    loop.addMutationForTest(100, 'node-a');
+    frameCapture.emitKeyframe(120);
+
+    const events = stream.push.mock.calls.map((c) => c[0]);
+    const anomaly = events.find((e) => e.type === 'perception-anomaly');
+    const escalation = events.find((e) => e.type === 'perception-escalation');
+
+    expect(anomaly).toBeDefined();
+    expect(anomaly!.payload).toMatchObject({ tier: 'frame', reason: 'mutation-outside-animation' });
+    expect(escalation).toBeDefined();
+    expect(escalation!.payload).toMatchObject({ from: 'frame', to: 'semantic' });
+  });
+
+  it('emits escalate on internalEmitter for the semantic loop', async () => {
+    const { session, frameCapture, loop } = setup({ warmupMs: 0 });
+    const handler = vi.fn();
+    session.internalEmitter.on('escalate', handler);
+    session.start(0);
+    await loop.start();
+
+    loop.addMutationForTest(100, 'node-a');
+    frameCapture.emitKeyframe(120);
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ from: 'frame' }),
+    );
+  });
+
+  it('trims recentMutations older than lookbackMs', async () => {
+    const { session, frameCapture, loop, stream } = setup({ lookbackMs: 100, warmupMs: 0 });
+    session.start(0);
+    await loop.start();
+
+    // Mutation at t=0, keyframe at t=500 → gap 500 > lookbackMs 100
+    loop.addMutationForTest(0, 'node-old');
+    frameCapture.emitKeyframe(500);
+
+    const anomalies = stream.push.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.type === 'perception-anomaly');
+    expect(anomalies).toHaveLength(0);
+  });
+
+  it('debounces back-to-back keyframes within coalesce window', async () => {
+    const { session, frameCapture, loop, stream } = setup({ warmupMs: 0, coalesceWindowMs: 100 });
+    session.start(0);
+    await loop.start();
+
+    loop.addMutationForTest(100, 'node-a');
+    frameCapture.emitKeyframe(110);   // anomaly fires
+    frameCapture.emitKeyframe(150);   // 150 - 110 = 40 < coalesceWindowMs 100 → suppressed
+
+    const anomalies = stream.push.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.type === 'perception-anomaly');
+    expect(anomalies).toHaveLength(1);
+  });
+
+  it('stop() unsubscribes from frameCapture and eventStream', async () => {
+    const { session, frameCapture, loop, stream } = setup({ warmupMs: 0 });
+    session.start(0);
+    await loop.start();
+    loop.stop();
+
+    loop.addMutationForTest(100, 'node-a');
+    frameCapture.emitKeyframe(120);
+
+    // After stop(), no ticks should be recorded.
+    const ticks = stream.push.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.type === 'perception-tick');
+    expect(ticks).toHaveLength(0);
+  });
+
+  it('warmup gate suppresses anomaly before warmupMs elapses', async () => {
+    const { session, frameCapture, loop, stream } = setup({ warmupMs: 500 });
+    session.start(0);
+    await loop.start();
+
+    // Mutation at t=100, keyframe at t=200 — still within 500ms warmup
+    loop.addMutationForTest(100, 'node-a');
+    frameCapture.emitKeyframe(200);
+
+    const anomalies = stream.push.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.type === 'perception-anomaly');
+    expect(anomalies).toHaveLength(0);
+  });
+
+  it('addMutationForTest populates recentMutations ring buffer', async () => {
+    const { loop } = setup();
+    loop.addMutationForTest(50, 'node-1');
+    loop.addMutationForTest(60, 'node-2');
+
+    const buf = loop.getRecentMutationsForTest();
+    expect(buf).toHaveLength(2);
+    expect(buf[0]).toEqual({ timestamp: 50, targetNodeId: 'node-1' });
+  });
+});

--- a/tests/unit/pipelines/perception/frame-loop.test.ts
+++ b/tests/unit/pipelines/perception/frame-loop.test.ts
@@ -65,7 +65,7 @@ function setup(config?: { lookbackMs?: number; coalesceWindowMs?: number; warmup
 describe('FrameLoop', () => {
   it('emits perception-tick { tier: frame, cause: keyframe } on each keyframe', async () => {
     const { session, frameCapture, loop, stream } = setup({ warmupMs: 0 });
-    session.start(0);
+    await session.start(0);
     await loop.start();
 
     frameCapture.emitKeyframe(50);
@@ -79,7 +79,7 @@ describe('FrameLoop', () => {
 
   it('tracks animation-start/end and suppresses anomaly while animation is active', async () => {
     const { session, frameCapture, loop, stream } = setup({ warmupMs: 0 });
-    session.start(0);
+    await session.start(0);
     await loop.start();
 
     // Start animation, add a mutation, fire keyframe — no anomaly expected.
@@ -105,7 +105,7 @@ describe('FrameLoop', () => {
 
   it('emits perception-anomaly and perception-escalation when detector fires', async () => {
     const { session, frameCapture, loop, stream } = setup({ warmupMs: 0 });
-    session.start(0);
+    await session.start(0);
     await loop.start();
 
     loop.addMutationForTest(100, 'node-a');
@@ -125,7 +125,7 @@ describe('FrameLoop', () => {
     const { session, frameCapture, loop } = setup({ warmupMs: 0 });
     const handler = vi.fn();
     session.internalEmitter.on('escalate', handler);
-    session.start(0);
+    await session.start(0);
     await loop.start();
 
     loop.addMutationForTest(100, 'node-a');
@@ -138,7 +138,7 @@ describe('FrameLoop', () => {
 
   it('trims recentMutations older than lookbackMs', async () => {
     const { session, frameCapture, loop, stream } = setup({ lookbackMs: 100, warmupMs: 0 });
-    session.start(0);
+    await session.start(0);
     await loop.start();
 
     // Mutation at t=0, keyframe at t=500 → gap 500 > lookbackMs 100
@@ -153,7 +153,7 @@ describe('FrameLoop', () => {
 
   it('debounces back-to-back keyframes within coalesce window', async () => {
     const { session, frameCapture, loop, stream } = setup({ warmupMs: 0, coalesceWindowMs: 100 });
-    session.start(0);
+    await session.start(0);
     await loop.start();
 
     loop.addMutationForTest(100, 'node-a');
@@ -168,7 +168,7 @@ describe('FrameLoop', () => {
 
   it('stop() unsubscribes from frameCapture and eventStream', async () => {
     const { session, frameCapture, loop, stream } = setup({ warmupMs: 0 });
-    session.start(0);
+    await session.start(0);
     await loop.start();
     loop.stop();
 
@@ -184,7 +184,7 @@ describe('FrameLoop', () => {
 
   it('warmup gate suppresses anomaly before warmupMs elapses', async () => {
     const { session, frameCapture, loop, stream } = setup({ warmupMs: 500 });
-    session.start(0);
+    await session.start(0);
     await loop.start();
 
     // Mutation at t=100, keyframe at t=200 — still within 500ms warmup

--- a/tests/unit/pipelines/perception/frame-loop.test.ts
+++ b/tests/unit/pipelines/perception/frame-loop.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { randomUUID } from 'node:crypto';
+import type { Page } from 'playwright';
 import { FrameLoop } from '../../../../src/pipelines/perception/frame-loop.js';
 import { PerceptionSession } from '../../../../src/pipelines/perception/session.js';
 import type { TemporalEventStream } from '../../../../src/pipelines/temporal/event-stream.js';
@@ -205,5 +206,135 @@ describe('FrameLoop', () => {
     const buf = loop.getRecentMutationsForTest();
     expect(buf).toHaveLength(2);
     expect(buf[0]).toEqual({ timestamp: 50, targetNodeId: 'node-1' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Page-side observer install + lifecycle tests
+//
+// These exercise the FrameLoop paths that use a Playwright Page. The pure
+// unit tests above pass `page: undefined` and never touch installPageObserver
+// or the framenavigated handler — meaning the two highest-priority fixes from
+// commit 4e53077 (framenavigated reinstall + WeakMap dispatcher) had ZERO
+// regression coverage. The block below locks both in, plus the C3 fix that
+// catches errors in the fire-and-forget nav listener.
+// ---------------------------------------------------------------------------
+
+/** Minimal Page mock — just the surface FrameLoop uses. */
+class FakePage extends EventEmitter {
+  exposeFunction = vi.fn<(name: string, fn: (...args: any[]) => any) => Promise<void>>(
+    async (name: string, fn: (...args: any[]) => any) => {
+      this.exposedFns.set(name, fn);
+    },
+  );
+  evaluate = vi.fn<(fn: (...args: any[]) => any) => Promise<unknown>>(async () => undefined);
+  exposedFns = new Map<string, (...args: any[]) => any>();
+}
+
+function setupWithPage(config?: { warmupMs?: number; lookbackMs?: number; coalesceWindowMs?: number }) {
+  const stream = new FakeEventStream();
+  const session = new PerceptionSession({
+    eventStream: stream as unknown as TemporalEventStream,
+  });
+  const frameCapture = new FakeFrameCapture();
+  const page = new FakePage();
+  const loop = new FrameLoop({
+    session,
+    frameCapture: frameCapture as any,
+    eventStream: stream as unknown as TemporalEventStream,
+    page: page as unknown as Page,
+    config,
+  });
+  return { stream, session, frameCapture, page, loop };
+}
+
+describe('FrameLoop page-side observer', () => {
+  it('reinstalls the page-side observer when framenavigated fires (regression lock for 4e53077 fix #1)', async () => {
+    const { session, page, loop } = setupWithPage({ warmupMs: 0 });
+    await session.start(0);
+    await loop.start();
+
+    // Sanity: initial install ran once.
+    expect(page.evaluate).toHaveBeenCalledTimes(1);
+
+    // Simulate Playwright's SPA navigation event.
+    page.emit('framenavigated');
+    // The handler is async; drain microtasks so the await completes.
+    await new Promise((r) => setImmediate(r));
+
+    // Observer must be reinstalled — evaluate ran a second time.
+    expect(page.evaluate).toHaveBeenCalledTimes(2);
+    loop.stop();
+  });
+
+  it('WeakMap dispatcher routes mutations to the current FrameLoop on second-session reattach (regression lock for 4e53077 fix #2)', async () => {
+    const { session: s1, page, loop: loop1 } = setupWithPage({ warmupMs: 0 });
+    await s1.start(0);
+    await loop1.start();
+
+    // Capture the closure that exposeFunction registered on the page side.
+    const exposedClosure = page.exposedFns.get('__uipeFrameLoopMutation');
+    expect(exposedClosure).toBeDefined();
+
+    loop1.stop();
+
+    // Second session on the same page. exposeFunction throws "already
+    // registered" (the closure from loop1 is still bound on the page).
+    page.exposeFunction.mockImplementationOnce(async () => {
+      throw new Error('Function "__uipeFrameLoopMutation" has been already registered');
+    });
+
+    const stream2 = new FakeEventStream();
+    const session2 = new PerceptionSession({
+      eventStream: stream2 as unknown as TemporalEventStream,
+    });
+    const frameCapture2 = new FakeFrameCapture();
+    const loop2 = new FrameLoop({
+      session: session2,
+      frameCapture: frameCapture2 as any,
+      eventStream: stream2 as unknown as TemporalEventStream,
+      page: page as unknown as Page,
+      config: { warmupMs: 0 },
+    });
+    await session2.start(100);
+    await loop2.start();
+
+    // Invoke the OLD closure (still bound from loop1's exposeFunction call).
+    exposedClosure!({ timestamp: 200, targetNodeId: 'mut-7' });
+
+    // The mutation must land in loop2's buffer via the WeakMap redirect.
+    const buf = loop2.getRecentMutationsForTest();
+    expect(buf).toEqual([{ timestamp: 200, targetNodeId: 'mut-7' }]);
+    loop2.stop();
+  });
+
+  it('framenavigated reinstall errors are caught and logged, not unhandled rejections (C3 fix)', async () => {
+    const { session, page, loop } = setupWithPage({ warmupMs: 0 });
+    await session.start(0);
+    await loop.start();
+
+    // After the initial install, make the next evaluate reject — simulating
+    // a TargetClosedError mid-nav, a sharp crash, etc.
+    page.evaluate.mockRejectedValueOnce(new Error('Target page closed during nav'));
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+
+    try {
+      page.emit('framenavigated');
+      // Drain both the framenavigated callback and the rejected-promise tick.
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      expect(unhandled).toEqual([]);
+      // Loop is still alive — keyframe handling continues.
+      const frameCapture = (loop as any).frameCapture as FakeFrameCapture;
+      frameCapture.emitKeyframe(50);
+      expect((loop as any).recentMutations).toBeDefined();
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+      loop.stop();
+    }
   });
 });

--- a/tests/unit/pipelines/perception/frame-loop.test.ts
+++ b/tests/unit/pipelines/perception/frame-loop.test.ts
@@ -331,6 +331,59 @@ describe('FrameLoop page-side observer', () => {
     expect(ticks).toHaveLength(0);
   });
 
+  it('framenavigated logs known races (target closed) at WARN, not ERROR (P2-N1 fix)', async () => {
+    const { session, page, loop } = setupWithPage({ warmupMs: 0 });
+    await session.start(0);
+    await loop.start();
+    page.evaluate.mockRejectedValueOnce(new Error('Target page closed during nav'));
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      page.emit('framenavigated');
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      const warned = logSpy.mock.calls.some((c) => {
+        const [prefix] = c;
+        return typeof prefix === 'string' && prefix.includes('[WARN]');
+      });
+      const errored = logSpy.mock.calls.some((c) => {
+        const [prefix] = c;
+        return typeof prefix === 'string' && prefix.includes('[ERROR]');
+      });
+      expect(warned).toBe(true);
+      expect(errored).toBe(false);
+    } finally {
+      logSpy.mockRestore();
+      loop.stop();
+    }
+  });
+
+  it('framenavigated logs unexpected errors at ERROR with UNEXPECTED prefix (P2-N1 fix)', async () => {
+    const { session, page, loop } = setupWithPage({ warmupMs: 0 });
+    await session.start(0);
+    await loop.start();
+    // Not a known Playwright race — programmer bug, exotic infra, etc.
+    page.evaluate.mockRejectedValueOnce(new TypeError("Cannot read properties of undefined (reading 'foo')"));
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      page.emit('framenavigated');
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      const unexpectedError = logSpy.mock.calls.find((c) => {
+        const [prefix, msg] = c;
+        return typeof prefix === 'string' && prefix.includes('[ERROR]') &&
+               typeof msg === 'string' && /UNEXPECTED/i.test(msg);
+      });
+      expect(unexpectedError).toBeDefined();
+    } finally {
+      logSpy.mockRestore();
+      loop.stop();
+    }
+  });
+
   it('framenavigated reinstall errors are caught and logged, not unhandled rejections (C3 fix)', async () => {
     const { session, page, loop } = setupWithPage({ warmupMs: 0 });
     await session.start(0);

--- a/tests/unit/pipelines/perception/intent-loop.test.ts
+++ b/tests/unit/pipelines/perception/intent-loop.test.ts
@@ -311,6 +311,50 @@ describe('IntentLoop', () => {
     }
   });
 
+  it('does not bump vlmCalls.errorCount when stop() arrives during an in-flight classify that later throws (P2-I1 fix)', async () => {
+    const { session, stream } = mkSession();
+    await session.start(0);
+    let rejectClassify: (e: Error) => void = () => {};
+    let classifyCalled: () => void = () => {};
+    const classifyEntered = new Promise<void>((r) => { classifyCalled = r; });
+    const classify = vi.fn(
+      () => new Promise<string>((_, rej) => {
+        rejectClassify = rej;
+        classifyCalled();
+      }),
+    );
+    const getScreenshot = vi.fn(async () => PNG);
+    const loop = new IntentLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      getScreenshot,
+      classifyByVlm: classify,
+    });
+    const recordVlmErrorSpy = vi.spyOn(session, 'recordVlmError');
+    loop.start();
+
+    session.internalEmitter.emit('escalate', {
+      from: 'semantic',
+      regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }],
+    });
+
+    // Wait for classify to actually be entered — only then is rejectClassify
+    // a real reject fn. Avoids the microtask-timing flake of Promise.resolve.
+    await classifyEntered;
+
+    // Stop while the VLM call is in flight.
+    loop.stop();
+
+    // Now make the in-flight classify REJECT. recordVlmError must NOT be
+    // called against a stopped session — mirroring how the success-path
+    // recordIntentResult is gated by !this.running.
+    rejectClassify(new Error('vlm-late-fail'));
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(recordVlmErrorSpy).not.toHaveBeenCalled();
+    expect(session.getSummary().vlmCalls.errorCount).toBeUndefined();
+  });
+
   it('logs when getScreenshot throws and does not produce an unhandled rejection (G1)', async () => {
     const { session, stream } = mkSession();
     await session.start(0);

--- a/tests/unit/pipelines/perception/intent-loop.test.ts
+++ b/tests/unit/pipelines/perception/intent-loop.test.ts
@@ -199,6 +199,96 @@ describe('IntentLoop', () => {
     expect(successful).toHaveLength(1);
   });
 
+  it('does not record intent results when stop() arrives during an in-flight classify (C1 regression lock for 4e53077 fix #5)', async () => {
+    const { session, stream } = mkSession();
+    await session.start(0);
+    let resolveClassify: (v: string) => void = () => {};
+    const classify = vi.fn(
+      () => new Promise<string>((r) => { resolveClassify = r; }),
+    );
+    const getScreenshot = vi.fn(async () => PNG);
+    const loop = new IntentLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      getScreenshot,
+      classifyByVlm: classify,
+    });
+    loop.start();
+
+    session.internalEmitter.emit('escalate', {
+      from: 'semantic',
+      regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }],
+    });
+
+    // Let the drain reach the classify await.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Stop while the VLM call is in flight.
+    loop.stop();
+
+    // Now resolve the classify — the result must NOT be recorded.
+    resolveClassify('LateAnswer');
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(intentResultCalls(stream)).toHaveLength(0);
+  });
+
+  it('logs a warning when getScreenshot returns null instead of silently dropping the pending queue (silent-failure #5)', async () => {
+    const { session, stream } = mkSession();
+    await session.start(0);
+    const classify = vi.fn(async () => 'X');
+    const getScreenshot = vi.fn(async () => null);
+    const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      loop.start();
+      session.internalEmitter.emit('escalate', {
+        from: 'semantic',
+        regions: [
+          { nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } },
+          { nodeId: 'b', bbox: { x: 20, y: 0, w: 10, h: 10 } },
+        ],
+      });
+      await new Promise((r) => setTimeout(r, 0));
+
+      const warned = logSpy.mock.calls.some((call) => {
+        const [prefix, message] = call;
+        return (
+          typeof prefix === 'string' &&
+          prefix.includes('[WARN]') &&
+          typeof message === 'string' &&
+          /screenshot/i.test(message)
+        );
+      });
+      expect(warned).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('drain() returns immediately when invoked after stop (belt-and-suspenders guard)', async () => {
+    const { session, stream } = mkSession();
+    await session.start(0);
+    const classify = vi.fn(async () => 'X');
+    const getScreenshot = vi.fn(async () => PNG);
+    const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
+    loop.start();
+
+    // Simulate the race: an enqueue happens, then stop runs, then a stale
+    // drain kicks. (We splice pending directly to model "post-stop pending"
+    // since the real onEscalate path is unsubscribed by stop().)
+    (loop as any).pending.push({ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } });
+    loop.stop();
+    // Refill pending to simulate a queued item surviving stop.
+    (loop as any).pending.push({ nodeId: 'b', bbox: { x: 0, y: 0, w: 10, h: 10 } });
+
+    await (loop as any).drain();
+    expect(classify).not.toHaveBeenCalled();
+    expect(getScreenshot).not.toHaveBeenCalled();
+  });
+
   it('ignores escalation events whose from is not semantic', async () => {
     const { session, stream } = mkSession();
     await session.start(0);

--- a/tests/unit/pipelines/perception/intent-loop.test.ts
+++ b/tests/unit/pipelines/perception/intent-loop.test.ts
@@ -64,7 +64,7 @@ function tickCalls(stream: FakeEventStream, tier: string) {
 describe('IntentLoop', () => {
   it('does not call VLM unless an escalation arrives', async () => {
     const { session, stream } = mkSession();
-    session.start(0);
+    await session.start(0);
     const classify = vi.fn(async () => 'X');
     const getScreenshot = vi.fn(async () => PNG);
     const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
@@ -75,7 +75,7 @@ describe('IntentLoop', () => {
 
   it('classifies each region in an escalation and emits perception-intent-result', async () => {
     const { session, stream } = mkSession();
-    session.start(0);
+    await session.start(0);
     const classify = vi.fn(async () => 'AnimatedCounter');
     const getScreenshot = vi.fn(async () => PNG);
     const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
@@ -97,7 +97,7 @@ describe('IntentLoop', () => {
 
   it('emits a single perception-tick for the drain (not per-region)', async () => {
     const { session, stream } = mkSession();
-    session.start(0);
+    await session.start(0);
     const classify = vi.fn(async () => 'X');
     const getScreenshot = vi.fn(async () => PNG);
     const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
@@ -118,7 +118,7 @@ describe('IntentLoop', () => {
 
   it('drops oldest when pending queue exceeds maxPending', async () => {
     const { session, stream } = mkSession();
-    session.start(0);
+    await session.start(0);
 
     // classifier that never resolves until we call resolveClassify
     let resolveClassify: (v: string) => void = () => {};
@@ -158,7 +158,7 @@ describe('IntentLoop', () => {
 
   it('skips classification when screenshot provider returns null', async () => {
     const { session, stream } = mkSession();
-    session.start(0);
+    await session.start(0);
     const classify = vi.fn(async () => 'X');
     const getScreenshot = vi.fn(async () => null);
     const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
@@ -175,7 +175,7 @@ describe('IntentLoop', () => {
 
   it('continues past a per-region classifier error', async () => {
     const { session, stream } = mkSession();
-    session.start(0);
+    await session.start(0);
     const classify = vi.fn()
       .mockImplementationOnce(async () => { throw new Error('boom'); })
       .mockImplementationOnce(async () => 'OK');
@@ -201,7 +201,7 @@ describe('IntentLoop', () => {
 
   it('ignores escalation events whose from is not semantic', async () => {
     const { session, stream } = mkSession();
-    session.start(0);
+    await session.start(0);
     const classify = vi.fn(async () => 'X');
     const getScreenshot = vi.fn(async () => PNG);
     const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });

--- a/tests/unit/pipelines/perception/intent-loop.test.ts
+++ b/tests/unit/pipelines/perception/intent-loop.test.ts
@@ -199,6 +199,49 @@ describe('IntentLoop', () => {
     expect(successful).toHaveLength(1);
   });
 
+  it('records vlmCalls.errorCount and preserves error stack on classify failure (I2 fix)', async () => {
+    const { session, stream } = mkSession();
+    await session.start(0);
+    const classify = vi.fn(async () => { throw new Error('vlm-boom'); });
+    const getScreenshot = vi.fn(async () => PNG);
+    const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
+    loop.start();
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      session.internalEmitter.emit('escalate', {
+        from: 'semantic',
+        regions: [
+          { nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } },
+          { nodeId: 'b', bbox: { x: 20, y: 0, w: 10, h: 10 } },
+        ],
+      });
+      await new Promise((r) => setTimeout(r, 0));
+
+      // Summary surfaces the error count (additive optional field).
+      const summary = session.getSummary();
+      expect(summary.vlmCalls.errorCount).toBe(2);
+
+      // Log call preserves the stack instead of collapsing to `Error: msg`.
+      const errorLog = logSpy.mock.calls.find((call) => {
+        const [prefix, message] = call;
+        return (
+          typeof prefix === 'string' &&
+          prefix.includes('[WARN]') &&
+          typeof message === 'string' &&
+          /classification failed/i.test(message)
+        );
+      });
+      expect(errorLog).toBeDefined();
+      const data = errorLog?.[2] as { error?: string };
+      expect(typeof data?.error).toBe('string');
+      // A real stack contains a frame; `String(new Error("x"))` is just `Error: x`.
+      expect(data!.error).toMatch(/\bat\b/);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
   it('does not record intent results when stop() arrives during an in-flight classify (C1 regression lock for 4e53077 fix #5)', async () => {
     const { session, stream } = mkSession();
     await session.start(0);

--- a/tests/unit/pipelines/perception/intent-loop.test.ts
+++ b/tests/unit/pipelines/perception/intent-loop.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { randomUUID } from 'node:crypto';
+import type { TimelineEvent } from '../../../../src/pipelines/temporal/collectors/types.js';
+
+// ---------------------------------------------------------------------------
+// Sharp mock — must be hoisted before imports that use sharp
+// ---------------------------------------------------------------------------
+
+vi.mock('sharp', () => {
+  // Stub: sharp(buf).extract(...).png().toBuffer() returns a fixed PNG buffer
+  const sharpMock = vi.fn(() => ({
+    extract: vi.fn().mockReturnThis(),
+    png: vi.fn().mockReturnThis(),
+    toBuffer: vi.fn(async () => Buffer.from([0x89, 0x50, 0x4e, 0x47])),
+  }));
+  return { default: sharpMock };
+});
+
+import { IntentLoop } from '../../../../src/pipelines/perception/intent-loop.js';
+import { PerceptionSession } from '../../../../src/pipelines/perception/session.js';
+import type { TemporalEventStream } from '../../../../src/pipelines/temporal/event-stream.js';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeEventStream extends EventEmitter {
+  push = vi.fn((_event: TimelineEvent) => {
+    // no-op in unit tests
+  });
+}
+
+function mkSession() {
+  const stream = new FakeEventStream();
+  const session = new PerceptionSession({
+    eventStream: stream as unknown as TemporalEventStream,
+  });
+  return { session, stream };
+}
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+
+// ---------------------------------------------------------------------------
+// Helpers to inspect push calls by event type
+// ---------------------------------------------------------------------------
+
+function intentResultCalls(stream: FakeEventStream) {
+  return stream.push.mock.calls
+    .map((c) => c[0])
+    .filter((e) => e.type === 'perception-intent-result');
+}
+
+function tickCalls(stream: FakeEventStream, tier: string) {
+  return stream.push.mock.calls
+    .map((c) => c[0])
+    .filter((e) => e.type === 'perception-tick' && (e.payload as any).tier === tier);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('IntentLoop', () => {
+  it('does not call VLM unless an escalation arrives', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const classify = vi.fn(async () => 'X');
+    const getScreenshot = vi.fn(async () => PNG);
+    const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
+    loop.start();
+    await Promise.resolve();
+    expect(classify).not.toHaveBeenCalled();
+  });
+
+  it('classifies each region in an escalation and emits perception-intent-result', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const classify = vi.fn(async () => 'AnimatedCounter');
+    const getScreenshot = vi.fn(async () => PNG);
+    const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
+    loop.start();
+
+    session.internalEmitter.emit('escalate', {
+      from: 'semantic',
+      regions: [
+        { nodeId: 'a', bbox: { x: 0, y: 0, w: 50, h: 30 } },
+        { nodeId: 'b', bbox: { x: 60, y: 0, w: 50, h: 30 } },
+      ],
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(classify).toHaveBeenCalledTimes(2);
+    expect(intentResultCalls(stream)).toHaveLength(2);
+  });
+
+  it('emits a single perception-tick for the drain (not per-region)', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const classify = vi.fn(async () => 'X');
+    const getScreenshot = vi.fn(async () => PNG);
+    const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
+    loop.start();
+
+    session.internalEmitter.emit('escalate', {
+      from: 'semantic',
+      regions: [
+        { nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } },
+        { nodeId: 'b', bbox: { x: 20, y: 0, w: 10, h: 10 } },
+      ],
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(tickCalls(stream, 'intent')).toHaveLength(1);
+  });
+
+  it('drops oldest when pending queue exceeds maxPending', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+
+    // classifier that never resolves until we call resolveClassify
+    let resolveClassify: (v: string) => void = () => {};
+    const classify = vi.fn(
+      () => new Promise<string>((r) => { resolveClassify = r; }),
+    );
+    const getScreenshot = vi.fn(async () => PNG);
+    const loop = new IntentLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      getScreenshot,
+      classifyByVlm: classify,
+      config: { maxPending: 2 },
+    });
+    loop.start();
+
+    // Fire 5 escalations — first starts immediately (drain picks it up),
+    // next ones queue up, exceeding maxPending=2 so oldest get dropped.
+    for (let i = 0; i < 5; i++) {
+      session.internalEmitter.emit('escalate', {
+        from: 'semantic',
+        regions: [{ nodeId: `n-${i}`, bbox: { x: 0, y: 0, w: 10, h: 10 } }],
+      });
+    }
+    // Let the first drain start
+    await Promise.resolve();
+
+    // Unblock the in-flight classifier
+    resolveClassify('X');
+    // Let the rest drain
+    await new Promise((r) => setTimeout(r, 20));
+
+    // With maxPending=2, at most 3 items can complete (1 in-flight + 2 in queue)
+    // But drops mean fewer. Assert it's strictly less than 5 (dropped at least some).
+    expect(intentResultCalls(stream).length).toBeLessThan(5);
+  });
+
+  it('skips classification when screenshot provider returns null', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const classify = vi.fn(async () => 'X');
+    const getScreenshot = vi.fn(async () => null);
+    const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
+    loop.start();
+
+    session.internalEmitter.emit('escalate', {
+      from: 'semantic',
+      regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }],
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(classify).not.toHaveBeenCalled();
+  });
+
+  it('continues past a per-region classifier error', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const classify = vi.fn()
+      .mockImplementationOnce(async () => { throw new Error('boom'); })
+      .mockImplementationOnce(async () => 'OK');
+    const getScreenshot = vi.fn(async () => PNG);
+    const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
+    loop.start();
+
+    session.internalEmitter.emit('escalate', {
+      from: 'semantic',
+      regions: [
+        { nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } },
+        { nodeId: 'b', bbox: { x: 20, y: 0, w: 10, h: 10 } },
+      ],
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const successful = intentResultCalls(stream).filter(
+      (e) => (e.payload as any).classification === 'OK',
+    );
+    expect(successful).toHaveLength(1);
+  });
+
+  it('ignores escalation events whose from is not semantic', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const classify = vi.fn(async () => 'X');
+    const getScreenshot = vi.fn(async () => PNG);
+    const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
+    loop.start();
+
+    session.internalEmitter.emit('escalate', {
+      from: 'frame',
+      regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }],
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(classify).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/pipelines/perception/intent-loop.test.ts
+++ b/tests/unit/pipelines/perception/intent-loop.test.ts
@@ -311,6 +311,73 @@ describe('IntentLoop', () => {
     }
   });
 
+  it('logs when getScreenshot throws and does not produce an unhandled rejection (G1)', async () => {
+    const { session, stream } = mkSession();
+    await session.start(0);
+    const classify = vi.fn(async () => 'X');
+    const getScreenshot = vi.fn(async () => { throw new Error('target closed'); });
+    const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (r: unknown) => unhandled.push(r);
+    process.on('unhandledRejection', onUnhandled);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      loop.start();
+      session.internalEmitter.emit('escalate', {
+        from: 'semantic',
+        regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }],
+      });
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(unhandled).toEqual([]);
+      const errored = logSpy.mock.calls.some((c) => {
+        const [prefix, msg] = c;
+        return typeof prefix === 'string' && prefix.includes('[ERROR]') &&
+               typeof msg === 'string' && /screenshot/i.test(msg);
+      });
+      expect(errored).toBe(true);
+      expect(classify).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+      logSpy.mockRestore();
+    }
+  });
+
+  it('bounds error log volume when getScreenshot perma-throws (P2-C1 circuit breaker, G2)', async () => {
+    const { session, stream } = mkSession();
+    await session.start(0);
+    const classify = vi.fn(async () => 'X');
+    const getScreenshot = vi.fn(async () => { throw new Error('target closed'); });
+    const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      loop.start();
+      // Fire 20 escalations; each kicks a drain that hits the throwing
+      // screenshot. Without bounding, this produces 20 ERROR lines.
+      for (let i = 0; i < 20; i++) {
+        session.internalEmitter.emit('escalate', {
+          from: 'semantic',
+          regions: [{ nodeId: `n-${i}`, bbox: { x: 0, y: 0, w: 10, h: 10 } }],
+        });
+        await new Promise((r) => setTimeout(r, 0));
+      }
+
+      const errorLogs = logSpy.mock.calls.filter((c) => {
+        const [prefix, msg] = c;
+        return typeof prefix === 'string' && prefix.includes('[ERROR]') &&
+               typeof msg === 'string' && /screenshot/i.test(msg);
+      });
+      // Circuit breaker bounds total per-failure ERROR lines to at most
+      // a small constant (threshold + the "suppressing" notice) regardless
+      // of how many escalations arrived.
+      expect(errorLogs.length).toBeLessThanOrEqual(5);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
   it('drain() returns immediately when invoked after stop (belt-and-suspenders guard)', async () => {
     const { session, stream } = mkSession();
     await session.start(0);

--- a/tests/unit/pipelines/perception/semantic-loop.test.ts
+++ b/tests/unit/pipelines/perception/semantic-loop.test.ts
@@ -53,6 +53,115 @@ describe('SemanticLoop', () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
+  it('does not record a ghost tick when tick body throws (P2-H2 fix)', async () => {
+    const { session, stream } = mkSession();
+    await session.start(0);
+    const structural = {
+      extractStructure: vi.fn(async () => { throw new Error('extract-boom'); }),
+    } as unknown as StructuralPipeline;
+    const indexer = mkIndexer(new Map());
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      indexer,
+      structuralPipeline: structural,
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      loop.start();
+      session.internalEmitter.emit('escalate', { from: 'frame', regions: [] });
+      await vi.advanceTimersByTimeAsync(10);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Tick body threw — tickCounts.semantic must NOT have been bumped.
+      // Previously recordTick ran BEFORE the try, so a failed tick still
+      // showed up in the summary as a successful tick.
+      expect(session.getSummary().tickCounts.semantic).toBe(0);
+    } finally {
+      logSpy.mockRestore();
+      loop.stop();
+    }
+  });
+
+  it('prevents concurrent first-tick when a second escalate arrives mid-await (P2-H1 fix)', async () => {
+    const { session, stream } = mkSession();
+    await session.start(0);
+    // Hold the first extractStructure call open so we can race a second escalate.
+    let resolveFirst: (v: any[]) => void = () => {};
+    let callCount = 0;
+    const extractStructure = vi.fn((): Promise<any[]> => {
+      callCount += 1;
+      if (callCount === 1) {
+        return new Promise<any[]>((r) => { resolveFirst = r; });
+      }
+      return Promise.resolve([]);
+    });
+    const structural = { extractStructure } as unknown as StructuralPipeline;
+    const indexer = mkIndexer(new Map());
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      indexer,
+      structuralPipeline: structural,
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+
+    // First escalate — fires scheduleWake → tick → awaits extractStructure.
+    session.internalEmitter.emit('escalate', { from: 'frame', regions: [] });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(extractStructure).toHaveBeenCalledTimes(1);
+
+    // Second escalate ARRIVES mid-await. Previously: lastTickMs === 0 carve-out
+    // let this run a second tick concurrently with the first. After the fix,
+    // an inFlight guard suppresses the concurrent re-entry.
+    session.internalEmitter.emit('escalate', { from: 'frame', regions: [] });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(extractStructure).toHaveBeenCalledTimes(1);
+
+    // Resolve the first tick so the test cleans up.
+    resolveFirst([]);
+    await Promise.resolve();
+    await Promise.resolve();
+    loop.stop();
+  });
+
+  it('coalesces rapid scheduleWake calls into a single setTimeout (P2-I2 fix)', async () => {
+    const { session, stream } = mkSession();
+    await session.start(0);
+    const structural = mkStructural([]);
+    const indexer = mkIndexer(new Map());
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      indexer,
+      structuralPipeline: structural,
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+
+    // Spy on setTimeout BEFORE firing escalates so we count just the loop's
+    // schedules, not vitest's internal ones.
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    // Two escalates in the same JS turn — previously each call overwrote
+    // this.wakeTimer without clearing the prior handle (leaked timer ref).
+    session.internalEmitter.emit('escalate', { from: 'frame', regions: [] });
+    session.internalEmitter.emit('escalate', { from: 'frame', regions: [] });
+
+    // Only one timer should be scheduled for the same pending escalation.
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+
+    setTimeoutSpy.mockRestore();
+    await vi.advanceTimersByTimeAsync(10);
+    loop.stop();
+  });
+
   it('catches tick errors and does not advance lastTickMs so the next escalation retries (I3 fix)', async () => {
     const { session, stream } = mkSession();
     await session.start(0);
@@ -112,8 +221,10 @@ describe('SemanticLoop', () => {
       const ticks = stream.push.mock.calls
         .map((c) => c[0])
         .filter((e) => e.type === 'perception-tick' && (e.payload as any).tier === 'semantic');
-      // First tick recorded before the throw; second tick recorded on retry.
-      expect(ticks.length).toBeGreaterThanOrEqual(2);
+      // Failed tick records nothing (P2-H2 fix removed ghost ticks); only
+      // the successful retry records one. What we're proving here is that
+      // the cadence gate didn't silently skip the retry.
+      expect(ticks.length).toBeGreaterThanOrEqual(1);
     } finally {
       process.off('unhandledRejection', onUnhandled);
       logSpy.mockRestore();

--- a/tests/unit/pipelines/perception/semantic-loop.test.ts
+++ b/tests/unit/pipelines/perception/semantic-loop.test.ts
@@ -130,6 +130,31 @@ describe('SemanticLoop', () => {
     loop.stop();
   });
 
+  it('stop() calls clearTimeout on the pending wakeTimer (G6)', async () => {
+    const { session, stream } = mkSession();
+    await session.start(0);
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      indexer: mkIndexer(new Map()),
+      structuralPipeline: mkStructural([]),
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+    // Schedule a wake.
+    session.internalEmitter.emit('escalate', { from: 'frame', regions: [] });
+    expect((loop as any).wakeTimer).not.toBeNull();
+
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const handle = (loop as any).wakeTimer;
+    loop.stop();
+
+    expect(clearSpy).toHaveBeenCalledWith(handle);
+    expect((loop as any).wakeTimer).toBeNull();
+    clearSpy.mockRestore();
+  });
+
   it('coalesces rapid scheduleWake calls into a single setTimeout (P2-I2 fix)', async () => {
     const { session, stream } = mkSession();
     await session.start(0);

--- a/tests/unit/pipelines/perception/semantic-loop.test.ts
+++ b/tests/unit/pipelines/perception/semantic-loop.test.ts
@@ -53,9 +53,9 @@ describe('SemanticLoop', () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
-  it('does not tick when idle (no escalations, heartbeat fires but queue empty)', () => {
+  it('does not tick when idle (no escalations, heartbeat fires but queue empty)', async () => {
     const { session, stream } = mkSession();
-    session.start(0);
+    await session.start(0);
     const indexer = mkIndexer(new Map());
     const loop = new SemanticLoop({
       session,
@@ -75,7 +75,7 @@ describe('SemanticLoop', () => {
 
   it('wakes on escalation and emits a semantic tick', async () => {
     const { session, stream } = mkSession();
-    session.start(0);
+    await session.start(0);
     const indexer = mkIndexer(new Map());
     const loop = new SemanticLoop({
       session,
@@ -100,7 +100,7 @@ describe('SemanticLoop', () => {
 
   it('rate-bounds: two escalations within cadenceMs produce one tick', async () => {
     const { session, stream } = mkSession();
-    session.start(0);
+    await session.start(0);
     const indexer = mkIndexer(new Map());
     const loop = new SemanticLoop({
       session,
@@ -129,7 +129,7 @@ describe('SemanticLoop', () => {
 
   it('calls structural.extractStructure and indexer.run on each tick', async () => {
     const { session, stream } = mkSession();
-    session.start(0);
+    await session.start(0);
     const indexer = mkIndexer(new Map());
     const structural = mkStructural([{ id: 'n-1', tag: 'div' }]);
     const loop = new SemanticLoop({
@@ -155,7 +155,7 @@ describe('SemanticLoop', () => {
     // Structural pipeline returns node 'a'. Indexer returns 'a' as pending.
     // SemanticLoop should escalate using 'a' from the indexer, not 'x' from the frame payload.
     const { session, stream } = mkSession();
-    session.start(0);
+    await session.start(0);
     const componentMap = new Map([
       ['a', { name: null, status: 'pending', signature: 'sig-1' }],
     ]);
@@ -193,7 +193,7 @@ describe('SemanticLoop', () => {
 
   it('escalates to intent when indexer flags a node as pending', async () => {
     const { session, stream } = mkSession();
-    session.start(0);
+    await session.start(0);
     const componentMap = new Map([
       ['a', { name: null, status: 'pending', signature: 'sig-1' }],
     ]);
@@ -232,7 +232,7 @@ describe('SemanticLoop', () => {
 
   it('does not escalate to intent when no nodes are pending', async () => {
     const { session, stream } = mkSession();
-    session.start(0);
+    await session.start(0);
     const componentMap = new Map([
       ['a', { name: 'Button', source: 'rules', signature: 'sig-1' }],
     ]);
@@ -266,7 +266,7 @@ describe('SemanticLoop', () => {
 
   it('stop() unsubscribes — escalations after stop are ignored', async () => {
     const { session, stream } = mkSession();
-    session.start(0);
+    await session.start(0);
     const loop = new SemanticLoop({
       session,
       eventStream: stream as unknown as TemporalEventStream,

--- a/tests/unit/pipelines/perception/semantic-loop.test.ts
+++ b/tests/unit/pipelines/perception/semantic-loop.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { randomUUID } from 'node:crypto';
+import { SemanticLoop } from '../../../../src/pipelines/perception/semantic-loop.js';
+import { PerceptionSession } from '../../../../src/pipelines/perception/session.js';
+import type { TemporalEventStream } from '../../../../src/pipelines/temporal/event-stream.js';
+import type { StructuralPipeline } from '../../../../src/pipelines/structural/index.js';
+import type { Indexer } from '../../../../src/pipelines/component-index/indexer.js';
+import type { Page } from 'playwright';
+import type { TimelineEvent } from '../../../../src/pipelines/temporal/collectors/types.js';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeEventStream extends EventEmitter {
+  push = vi.fn((_event: TimelineEvent) => {
+    // no-op in unit tests; session calls this to record events
+  });
+}
+
+function mkSession() {
+  const stream = new FakeEventStream();
+  const session = new PerceptionSession({
+    eventStream: stream as unknown as TemporalEventStream,
+  });
+  return { session, stream };
+}
+
+function mkIndexer(componentMap: Map<string, any>): Indexer {
+  return {
+    run: vi.fn(async () => componentMap),
+  } as unknown as Indexer;
+}
+
+function mkStructural(nodes: any[]): StructuralPipeline {
+  return {
+    extractStructure: vi.fn(async () => nodes),
+  } as unknown as StructuralPipeline;
+}
+
+function mkPage(): Page {
+  return {
+    url: () => 'http://test',
+  } as unknown as Page;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SemanticLoop', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('does not tick when idle (no escalations, heartbeat fires but queue empty)', () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const indexer = mkIndexer(new Map());
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      indexer,
+      structuralPipeline: mkStructural([]),
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+    vi.advanceTimersByTime(500);
+    const tickCalls = stream.push.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.type === 'perception-tick' && (e.payload as any).tier === 'semantic');
+    expect(tickCalls).toHaveLength(0);
+  });
+
+  it('wakes on escalation and emits a semantic tick', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const indexer = mkIndexer(new Map());
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      indexer,
+      structuralPipeline: mkStructural([]),
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+    session.internalEmitter.emit('escalate', {
+      from: 'frame',
+      regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }],
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    const ticks = stream.push.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.type === 'perception-tick');
+    expect(ticks.length).toBeGreaterThanOrEqual(1);
+    expect(ticks[0].payload).toMatchObject({ tier: 'semantic', cause: 'escalation' });
+  });
+
+  it('rate-bounds: two escalations within cadenceMs produce one tick', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const indexer = mkIndexer(new Map());
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      indexer,
+      structuralPipeline: mkStructural([]),
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+    session.internalEmitter.emit('escalate', {
+      from: 'frame',
+      regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }],
+    });
+    await vi.advanceTimersByTimeAsync(50);
+    session.internalEmitter.emit('escalate', {
+      from: 'frame',
+      regions: [{ nodeId: 'b', bbox: { x: 0, y: 0, w: 10, h: 10 } }],
+    });
+    await vi.advanceTimersByTimeAsync(50);
+    const tickCalls = stream.push.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.type === 'perception-tick' && (e.payload as any).tier === 'semantic');
+    expect(tickCalls).toHaveLength(1);
+  });
+
+  it('calls structural.extractStructure and indexer.run on each tick', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const indexer = mkIndexer(new Map());
+    const structural = mkStructural([{ id: 'n-1', tag: 'div' }]);
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      indexer,
+      structuralPipeline: structural,
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+    session.internalEmitter.emit('escalate', {
+      from: 'frame',
+      regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }],
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(structural.extractStructure).toHaveBeenCalled();
+    expect(indexer.run).toHaveBeenCalled();
+  });
+
+  it('uses indexer output (not frame escalation payload) to determine pending regions', async () => {
+    // Frame escalation carries nodeId 'x' (a synthetic mut-N id).
+    // Structural pipeline returns node 'a'. Indexer returns 'a' as pending.
+    // SemanticLoop should escalate using 'a' from the indexer, not 'x' from the frame payload.
+    const { session, stream } = mkSession();
+    session.start(0);
+    const componentMap = new Map([
+      ['a', { name: null, status: 'pending', signature: 'sig-1' }],
+    ]);
+    const indexer = mkIndexer(componentMap);
+    const structural = mkStructural([
+      { id: 'a', tag: 'div', boundingBox: { x: 0, y: 0, width: 100, height: 50 } },
+    ]);
+
+    const intentHandler = vi.fn();
+    session.internalEmitter.on('escalate', (payload: any) => {
+      if (payload.from === 'semantic') intentHandler(payload);
+    });
+
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      indexer,
+      structuralPipeline: structural,
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+    // Frame escalation uses synthetic id 'x', not 'a'
+    session.internalEmitter.emit('escalate', {
+      from: 'frame',
+      regions: [{ nodeId: 'x', bbox: { x: 0, y: 0, w: 100, h: 50 } }],
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(intentHandler).toHaveBeenCalledWith(expect.objectContaining({ from: 'semantic' }));
+    // The escalation regions should reference 'a' (from indexer), not 'x' (from frame payload)
+    const call = intentHandler.mock.calls[0][0];
+    expect(call.regions[0].nodeId).toBe('a');
+  });
+
+  it('escalates to intent when indexer flags a node as pending', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const componentMap = new Map([
+      ['a', { name: null, status: 'pending', signature: 'sig-1' }],
+    ]);
+    const indexer = mkIndexer(componentMap);
+    const structural = mkStructural([
+      { id: 'a', tag: 'div', boundingBox: { x: 0, y: 0, width: 100, height: 50 } },
+    ]);
+
+    const intentHandler = vi.fn();
+    session.internalEmitter.on('escalate', (payload: any) => {
+      if (payload.from === 'semantic') intentHandler(payload);
+    });
+
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      indexer,
+      structuralPipeline: structural,
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+    session.internalEmitter.emit('escalate', {
+      from: 'frame',
+      regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 100, h: 50 } }],
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(intentHandler).toHaveBeenCalledWith(expect.objectContaining({ from: 'semantic' }));
+    const escalations = stream.push.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.type === 'perception-escalation');
+    expect(escalations.length).toBeGreaterThanOrEqual(1);
+    expect(escalations[0].payload).toMatchObject({ from: 'semantic', to: 'intent' });
+  });
+
+  it('does not escalate to intent when no nodes are pending', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const componentMap = new Map([
+      ['a', { name: 'Button', source: 'rules', signature: 'sig-1' }],
+    ]);
+    const indexer = mkIndexer(componentMap);
+    const structural = mkStructural([
+      { id: 'a', tag: 'button', boundingBox: { x: 0, y: 0, width: 100, height: 50 } },
+    ]);
+
+    const intentHandler = vi.fn();
+    session.internalEmitter.on('escalate', (payload: any) => {
+      if (payload.from === 'semantic') intentHandler(payload);
+    });
+
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      indexer,
+      structuralPipeline: structural,
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+    session.internalEmitter.emit('escalate', {
+      from: 'frame',
+      regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 100, h: 50 } }],
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(intentHandler).not.toHaveBeenCalled();
+  });
+
+  it('stop() unsubscribes — escalations after stop are ignored', async () => {
+    const { session, stream } = mkSession();
+    session.start(0);
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      indexer: mkIndexer(new Map()),
+      structuralPipeline: mkStructural([]),
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+    loop.stop();
+    session.internalEmitter.emit('escalate', {
+      from: 'frame',
+      regions: [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }],
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    const tickCalls = stream.push.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.type === 'perception-tick' && (e.payload as any).tier === 'semantic');
+    expect(tickCalls).toHaveLength(0);
+  });
+});

--- a/tests/unit/pipelines/perception/semantic-loop.test.ts
+++ b/tests/unit/pipelines/perception/semantic-loop.test.ts
@@ -53,6 +53,74 @@ describe('SemanticLoop', () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
+  it('catches tick errors and does not advance lastTickMs so the next escalation retries (I3 fix)', async () => {
+    const { session, stream } = mkSession();
+    await session.start(0);
+    // Structural pipeline rejects — previously this became an unhandled
+    // rejection from `void this.tick()` and `lastTickMs` was already advanced,
+    // gating out the next escalation silently.
+    const structural = {
+      extractStructure: vi.fn(async () => { throw new Error('extract-boom'); }),
+    } as unknown as StructuralPipeline;
+    const indexer = mkIndexer(new Map());
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      indexer,
+      structuralPipeline: structural,
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      loop.start();
+      session.internalEmitter.emit('escalate', { from: 'frame', regions: [] });
+      // Drain the setTimeout + the awaited rejection.
+      await vi.advanceTimersByTimeAsync(10);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(unhandled).toEqual([]);
+      // Warn was logged.
+      const warned = logSpy.mock.calls.some((c) => {
+        const [prefix, msg] = c;
+        return (
+          typeof prefix === 'string' &&
+          prefix.includes('[WARN]') &&
+          typeof msg === 'string' &&
+          /tick failed/i.test(msg)
+        );
+      });
+      expect(warned).toBe(true);
+
+      // lastTickMs must NOT have advanced — so a follow-up escalation
+      // arriving inside the cadence window still ticks.
+      expect((loop as any).lastTickMs).toBe(0);
+
+      // Send a second escalation; the gate should still let it through.
+      structural.extractStructure = vi.fn(async () => []) as any;
+      session.internalEmitter.emit('escalate', { from: 'frame', regions: [] });
+      await vi.advanceTimersByTimeAsync(10);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const ticks = stream.push.mock.calls
+        .map((c) => c[0])
+        .filter((e) => e.type === 'perception-tick' && (e.payload as any).tier === 'semantic');
+      // First tick recorded before the throw; second tick recorded on retry.
+      expect(ticks.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+      logSpy.mockRestore();
+      loop.stop();
+    }
+  });
+
   it('does not tick when idle (no escalations, heartbeat fires but queue empty)', async () => {
     const { session, stream } = mkSession();
     await session.start(0);

--- a/tests/unit/pipelines/perception/session.test.ts
+++ b/tests/unit/pipelines/perception/session.test.ts
@@ -48,6 +48,30 @@ describe('PerceptionSession lifecycle', () => {
     expect(() => session.stop(100)).toThrow();
   });
 
+  it('onPageClose logs (does not silently swallow) when stop() raises (I1 fix)', async () => {
+    await session.start(100);
+
+    // Force stop() to throw to simulate a teardown error mid-close (e.g.,
+    // page.off() raising after the page already disconnected).
+    const stopSpy = vi.spyOn(session, 'stop').mockImplementation(() => {
+      throw new Error('teardown failed');
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const onPageClose = (session as any).onPageClose as () => void;
+      // Must not throw — the close handler is fired by Playwright sync.
+      expect(() => onPageClose()).not.toThrow();
+      const errored = logSpy.mock.calls.some((call) => {
+        const [prefix] = call;
+        return typeof prefix === 'string' && prefix.includes('[ERROR]');
+      });
+      expect(errored).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+      stopSpy.mockRestore();
+    }
+  });
+
   it('recordTick increments tier count and emits perception-tick', async () => {
     await session.start(100);
     session.recordTick('frame', 'keyframe', 150);

--- a/tests/unit/pipelines/perception/session.test.ts
+++ b/tests/unit/pipelines/perception/session.test.ts
@@ -26,19 +26,19 @@ describe('PerceptionSession lifecycle', () => {
     expect(s.targetCadenceMs.intent).toBe(1000);
   });
 
-  it('start() sets startedAt', () => {
-    session.start(100);
+  it('start() sets startedAt', async () => {
+    await session.start(100);
     const s = session.getSummary();
     expect(s.startedAt).toBe(100);
   });
 
-  it('start() called twice throws', () => {
-    session.start(100);
-    expect(() => session.start(200)).toThrow();
+  it('start() called twice throws', async () => {
+    await session.start(100);
+    await expect(session.start(200)).rejects.toThrow();
   });
 
-  it('stop() sets durationMs based on time elapsed', () => {
-    session.start(100);
+  it('stop() sets durationMs based on time elapsed', async () => {
+    await session.start(100);
     session.stop(450);
     const s = session.getSummary();
     expect(s.durationMs).toBe(350);
@@ -48,8 +48,8 @@ describe('PerceptionSession lifecycle', () => {
     expect(() => session.stop(100)).toThrow();
   });
 
-  it('recordTick increments tier count and emits perception-tick', () => {
-    session.start(100);
+  it('recordTick increments tier count and emits perception-tick', async () => {
+    await session.start(100);
     session.recordTick('frame', 'keyframe', 150);
     const s = session.getSummary();
     expect(s.tickCounts.frame).toBe(1);
@@ -58,8 +58,8 @@ describe('PerceptionSession lifecycle', () => {
     );
   });
 
-  it('recordAnomaly increments anomalyCount and reason bucket', () => {
-    session.start(100);
+  it('recordAnomaly increments anomalyCount and reason bucket', async () => {
+    await session.start(100);
     session.recordAnomaly('frame', 'mutation-outside-animation', { mutationCount: 2, targetNodeIds: ['x', 'y'] }, 200);
     const s = session.getSummary();
     expect(s.anomalyCount).toBe(1);
@@ -73,8 +73,8 @@ describe('PerceptionSession lifecycle', () => {
     );
   });
 
-  it('recordEscalation increments escalationCount', () => {
-    session.start(100);
+  it('recordEscalation increments escalationCount', async () => {
+    await session.start(100);
     session.recordEscalation('frame', 'semantic', 'mutation-outside-animation', [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }], 250);
     expect(session.getSummary().escalationCount).toBe(1);
     expect(stream.push).toHaveBeenCalledWith(
@@ -86,8 +86,8 @@ describe('PerceptionSession lifecycle', () => {
     );
   });
 
-  it('recordIntentResult increments intentResultCount + vlmCalls.count', () => {
-    session.start(100);
+  it('recordIntentResult increments intentResultCount + vlmCalls.count', async () => {
+    await session.start(100);
     session.recordIntentResult(
       { nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } },
       'AnimatedCounter',
@@ -106,8 +106,8 @@ describe('PerceptionSession lifecycle', () => {
     );
   });
 
-  it('averageCadenceMs computes mean inter-tick interval per tier', () => {
-    session.start(0);
+  it('averageCadenceMs computes mean inter-tick interval per tier', async () => {
+    await session.start(0);
     session.recordTick('frame', 'keyframe', 100);
     session.recordTick('frame', 'keyframe', 300);   // gap 200
     session.recordTick('frame', 'keyframe', 500);   // gap 200
@@ -117,7 +117,7 @@ describe('PerceptionSession lifecycle', () => {
     expect(s.averageCadenceMs.intent).toBeNull();
   });
 
-  it('internalEmitter is a usable EventEmitter', () => {
+  it('internalEmitter is a usable EventEmitter', async () => {
     const handler = vi.fn();
     session.internalEmitter.on('escalate', handler);
     session.internalEmitter.emit('escalate', { from: 'frame', regions: [] });
@@ -154,10 +154,10 @@ describe('PerceptionSession composed with loops', () => {
     return { stream, frameCapture, indexer, structuralPipeline, page, classifyByVlm, getScreenshot };
   }
 
-  it('start() registers framenavigated and close handlers on the page', () => {
+  it('start() registers framenavigated and close handlers on the page', async () => {
     const deps = mkComposedDeps();
     const session = new PerceptionSession({ eventStream: deps.stream });
-    session.start(0, {
+    await session.start(0, {
       page: deps.page,
       frameCapture: deps.frameCapture,
       indexer: deps.indexer,
@@ -170,10 +170,10 @@ describe('PerceptionSession composed with loops', () => {
     session.stop(100);
   });
 
-  it('stop() cleanly removes page listeners', () => {
+  it('stop() cleanly removes page listeners', async () => {
     const deps = mkComposedDeps();
     const session = new PerceptionSession({ eventStream: deps.stream });
-    session.start(0, {
+    await session.start(0, {
       page: deps.page,
       frameCapture: deps.frameCapture,
       indexer: deps.indexer,
@@ -186,10 +186,10 @@ describe('PerceptionSession composed with loops', () => {
     expect(deps.page.off).toHaveBeenCalledWith('close', expect.any(Function));
   });
 
-  it('navigation event resets sessionStartMs and emits a navigation-reset tick', () => {
+  it('navigation event resets sessionStartMs and emits a navigation-reset tick', async () => {
     const deps = mkComposedDeps();
     const session = new PerceptionSession({ eventStream: deps.stream });
-    session.start(0, {
+    await session.start(0, {
       page: deps.page,
       frameCapture: deps.frameCapture,
       indexer: deps.indexer,
@@ -197,9 +197,16 @@ describe('PerceptionSession composed with loops', () => {
       classifyByVlm: deps.classifyByVlm,
       getScreenshot: deps.getScreenshot,
     });
-    // Find and invoke the framenavigated handler
-    const navHandler = deps.page.on.mock.calls.find((c: any[]) => c[0] === 'framenavigated')[1];
-    navHandler();
+    // Find and invoke the framenavigated handler registered by the session (onPageNav).
+    // FrameLoop also registers its own framenavigated handler; we want the session's one
+    // which resets startedAt and emits the navigation-reset tick.
+    const navCalls = deps.page.on.mock.calls.filter((c: any[]) => c[0] === 'framenavigated');
+    // Session's onPageNav is the one registered directly by session.start (not FrameLoop).
+    // It is always the last call because FrameLoop.start() runs before the session's page.on.
+    // We identify it by invoking all and checking the tick was emitted.
+    for (const [, handler] of navCalls) {
+      handler();
+    }
     expect(deps.stream.push).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'perception-tick',
@@ -209,10 +216,10 @@ describe('PerceptionSession composed with loops', () => {
     session.stop(100);
   });
 
-  it('page close auto-stops the session', () => {
+  it('page close auto-stops the session', async () => {
     const deps = mkComposedDeps();
     const session = new PerceptionSession({ eventStream: deps.stream });
-    session.start(0, {
+    await session.start(0, {
       page: deps.page,
       frameCapture: deps.frameCapture,
       indexer: deps.indexer,

--- a/tests/unit/pipelines/perception/session.test.ts
+++ b/tests/unit/pipelines/perception/session.test.ts
@@ -211,6 +211,46 @@ describe('PerceptionSession composed with loops', () => {
     session.stop(100);
   });
 
+  it('stop() runs all teardown steps even when one throws (P2-C2 fix)', async () => {
+    const deps = mkComposedDeps();
+    const session = new PerceptionSession({ eventStream: deps.stream });
+    await session.start(0, {
+      page: deps.page,
+      frameCapture: deps.frameCapture,
+      indexer: deps.indexer,
+      structuralPipeline: deps.structuralPipeline,
+      classifyByVlm: deps.classifyByVlm,
+      getScreenshot: deps.getScreenshot,
+    });
+
+    // Inject a throwing frameLoop.stop() to model TargetClosedError during teardown.
+    const frameLoopStop = vi.spyOn((session as any).frameLoop, 'stop')
+      .mockImplementation(() => { throw new Error('frameLoop teardown failed'); });
+    const semanticLoopStop = vi.spyOn((session as any).semanticLoop, 'stop');
+    const intentLoopStop = vi.spyOn((session as any).intentLoop, 'stop');
+
+    let thrown: unknown = null;
+    try { session.stop(100); } catch (e) { thrown = e; }
+
+    // All teardown steps must run regardless of the throw.
+    expect(frameLoopStop).toHaveBeenCalled();
+    expect(semanticLoopStop).toHaveBeenCalled();
+    expect(intentLoopStop).toHaveBeenCalled();
+    expect(deps.page.off).toHaveBeenCalledWith('framenavigated', expect.any(Function));
+    expect(deps.page.off).toHaveBeenCalledWith('close', expect.any(Function));
+
+    // Refs must all be nulled — session left in a coherent stopped state,
+    // not bricked half-way.
+    expect((session as any).frameLoop).toBeNull();
+    expect((session as any).semanticLoop).toBeNull();
+    expect((session as any).intentLoop).toBeNull();
+    expect((session as any).page).toBeNull();
+
+    // The underlying error is still surfaced (aggregated), not swallowed.
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(/frameLoop teardown failed/);
+  });
+
   it('stop() cleanly removes page listeners', async () => {
     const deps = mkComposedDeps();
     const session = new PerceptionSession({ eventStream: deps.stream });

--- a/tests/unit/pipelines/perception/session.test.ts
+++ b/tests/unit/pipelines/perception/session.test.ts
@@ -72,6 +72,36 @@ describe('PerceptionSession lifecycle', () => {
     }
   });
 
+  it('vlmCalls.errorCount is absent when no errors have been recorded (G3)', async () => {
+    await session.start(0);
+    session.recordIntentResult({ nodeId: 'a', bbox: { x: 0, y: 0, w: 1, h: 1 } }, 'X', 5, 10);
+    const s = session.getSummary();
+    expect(s.vlmCalls.count).toBe(1);
+    // errorCount stays absent (not 0, not present) when there are no errors
+    // — keeps the conditional-spread contract stable.
+    expect('errorCount' in s.vlmCalls).toBe(false);
+  });
+
+  it('recordVlmError bumps the error count and surfaces it in the summary (G4)', async () => {
+    await session.start(0);
+    session.recordVlmError();
+    session.recordVlmError();
+    const s = session.getSummary();
+    expect(s.vlmCalls.errorCount).toBe(2);
+    // No successful calls — count stays 0.
+    expect(s.vlmCalls.count).toBe(0);
+  });
+
+  it('averageCadenceMs.frame is null when only navigation-reset ticks have fired (G5)', async () => {
+    await session.start(0);
+    session.recordTick('frame', 'navigation-reset', 100);
+    session.recordTick('frame', 'navigation-reset', 5100);
+    const s = session.getSummary();
+    // Without any real-cadence samples, the average must be null (not 0,
+    // not a stale interval from the discontinuity).
+    expect(s.averageCadenceMs.frame).toBeNull();
+  });
+
   it('navigation-reset ticks do not skew averageCadenceMs.frame (I4 fix)', async () => {
     await session.start(0);
     // Steady 16 ms cadence

--- a/tests/unit/pipelines/perception/session.test.ts
+++ b/tests/unit/pipelines/perception/session.test.ts
@@ -72,6 +72,23 @@ describe('PerceptionSession lifecycle', () => {
     }
   });
 
+  it('navigation-reset ticks do not skew averageCadenceMs.frame (I4 fix)', async () => {
+    await session.start(0);
+    // Steady 16 ms cadence
+    session.recordTick('frame', 'keyframe', 100);
+    session.recordTick('frame', 'keyframe', 116);
+    // Page navigation 5 s later — should not be counted as a sample interval.
+    session.recordTick('frame', 'navigation-reset', 5116);
+    // Resume steady cadence after nav
+    session.recordTick('frame', 'keyframe', 5132);
+    session.recordTick('frame', 'keyframe', 5148);
+
+    const s = session.getSummary();
+    // Without the fix, the ~5000ms gap dominates and average lands well above
+    // 1 s. With the fix, average stays near 16 ms (real-cadence samples only).
+    expect(s.averageCadenceMs.frame).toBeLessThan(50);
+  });
+
   it('recordTick increments tier count and emits perception-tick', async () => {
     await session.start(100);
     session.recordTick('frame', 'keyframe', 150);

--- a/tests/unit/pipelines/perception/session.test.ts
+++ b/tests/unit/pipelines/perception/session.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PerceptionSession } from '../../../../src/pipelines/perception/session.js';
+import type { TemporalEventStream } from '../../../../src/pipelines/temporal/event-stream.js';
+
+function mkStream() {
+  return {
+    push: vi.fn(),
+  } as unknown as TemporalEventStream;
+}
+
+describe('PerceptionSession lifecycle', () => {
+  let stream: TemporalEventStream;
+  let session: PerceptionSession;
+
+  beforeEach(() => {
+    stream = mkStream();
+    session = new PerceptionSession({ eventStream: stream });
+  });
+
+  it('summary starts with zero counts and target cadences', () => {
+    const s = session.getSummary();
+    expect(s.tickCounts).toEqual({ frame: 0, semantic: 0, intent: 0 });
+    expect(s.anomalyCount).toBe(0);
+    expect(s.targetCadenceMs.semantic).toBe(200);
+    expect(s.targetCadenceMs.intent).toBe(1000);
+  });
+
+  it('start() sets startedAt', () => {
+    session.start(100);
+    const s = session.getSummary();
+    expect(s.startedAt).toBe(100);
+  });
+
+  it('start() called twice throws', () => {
+    session.start(100);
+    expect(() => session.start(200)).toThrow();
+  });
+
+  it('stop() sets durationMs based on time elapsed', () => {
+    session.start(100);
+    session.stop(450);
+    const s = session.getSummary();
+    expect(s.durationMs).toBe(350);
+  });
+
+  it('stop() without start throws', () => {
+    expect(() => session.stop(100)).toThrow();
+  });
+
+  it('recordTick increments tier count and emits perception-tick', () => {
+    session.start(100);
+    session.recordTick('frame', 'keyframe', 150);
+    const s = session.getSummary();
+    expect(s.tickCounts.frame).toBe(1);
+    expect(stream.push).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'perception-tick', timestamp: 150, payload: { tier: 'frame', cause: 'keyframe' } }),
+    );
+  });
+
+  it('recordAnomaly increments anomalyCount and reason bucket', () => {
+    session.start(100);
+    session.recordAnomaly('frame', 'mutation-outside-animation', { mutationCount: 2, targetNodeIds: ['x', 'y'] }, 200);
+    const s = session.getSummary();
+    expect(s.anomalyCount).toBe(1);
+    expect(s.anomaliesByReason['mutation-outside-animation']).toBe(1);
+    expect(stream.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'perception-anomaly',
+        timestamp: 200,
+        payload: expect.objectContaining({ tier: 'frame', reason: 'mutation-outside-animation' }),
+      }),
+    );
+  });
+
+  it('recordEscalation increments escalationCount', () => {
+    session.start(100);
+    session.recordEscalation('frame', 'semantic', 'mutation-outside-animation', [{ nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } }], 250);
+    expect(session.getSummary().escalationCount).toBe(1);
+    expect(stream.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'perception-escalation',
+        timestamp: 250,
+        payload: expect.objectContaining({ from: 'frame', to: 'semantic' }),
+      }),
+    );
+  });
+
+  it('recordIntentResult increments intentResultCount + vlmCalls.count', () => {
+    session.start(100);
+    session.recordIntentResult(
+      { nodeId: 'a', bbox: { x: 0, y: 0, w: 10, h: 10 } },
+      'AnimatedCounter',
+      300,
+      400,
+    );
+    const s = session.getSummary();
+    expect(s.intentResultCount).toBe(1);
+    expect(s.vlmCalls.count).toBe(1);
+    expect(stream.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'perception-intent-result',
+        timestamp: 400,
+        payload: expect.objectContaining({ classification: 'AnimatedCounter', classificationSource: 'vlm', durationMs: 300 }),
+      }),
+    );
+  });
+
+  it('averageCadenceMs computes mean inter-tick interval per tier', () => {
+    session.start(0);
+    session.recordTick('frame', 'keyframe', 100);
+    session.recordTick('frame', 'keyframe', 300);   // gap 200
+    session.recordTick('frame', 'keyframe', 500);   // gap 200
+    const s = session.getSummary();
+    expect(s.averageCadenceMs.frame).toBe(200);
+    expect(s.averageCadenceMs.semantic).toBeNull();
+    expect(s.averageCadenceMs.intent).toBeNull();
+  });
+
+  it('internalEmitter is a usable EventEmitter', () => {
+    const handler = vi.fn();
+    session.internalEmitter.on('escalate', handler);
+    session.internalEmitter.emit('escalate', { from: 'frame', regions: [] });
+    expect(handler).toHaveBeenCalledWith({ from: 'frame', regions: [] });
+  });
+
+  it('anomaliesByReason buckets initialized to zero even when no anomaly fired', () => {
+    const s = session.getSummary();
+    expect(s.anomaliesByReason['mutation-outside-animation']).toBe(0);
+  });
+
+  it('durationMs is 0 before start()', () => {
+    const s = session.getSummary();
+    expect(s.durationMs).toBe(0);
+  });
+});

--- a/tests/unit/pipelines/perception/session.test.ts
+++ b/tests/unit/pipelines/perception/session.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter as NodeEventEmitter } from 'node:events';
 import { PerceptionSession } from '../../../../src/pipelines/perception/session.js';
 import type { TemporalEventStream } from '../../../../src/pipelines/temporal/event-stream.js';
 
@@ -131,5 +132,96 @@ describe('PerceptionSession lifecycle', () => {
   it('durationMs is 0 before start()', () => {
     const s = session.getSummary();
     expect(s.durationMs).toBe(0);
+  });
+});
+
+describe('PerceptionSession composed with loops', () => {
+  function mkComposedDeps() {
+    const stream = new NodeEventEmitter() as any;
+    stream.push = vi.fn();
+    const frameCapture = new NodeEventEmitter() as any;
+    const indexer = { run: vi.fn(async () => new Map()) } as any;
+    const structuralPipeline = { extractStructure: vi.fn(async () => []) } as any;
+    const page = {
+      url: () => 'http://test',
+      on: vi.fn(),
+      off: vi.fn(),
+      exposeFunction: vi.fn(async () => {}),
+      evaluate: vi.fn(async () => {}),
+    } as any;
+    const classifyByVlm = vi.fn(async () => 'X');
+    const getScreenshot = vi.fn(async () => Buffer.from([0x89, 0x50]));
+    return { stream, frameCapture, indexer, structuralPipeline, page, classifyByVlm, getScreenshot };
+  }
+
+  it('start() registers framenavigated and close handlers on the page', () => {
+    const deps = mkComposedDeps();
+    const session = new PerceptionSession({ eventStream: deps.stream });
+    session.start(0, {
+      page: deps.page,
+      frameCapture: deps.frameCapture,
+      indexer: deps.indexer,
+      structuralPipeline: deps.structuralPipeline,
+      classifyByVlm: deps.classifyByVlm,
+      getScreenshot: deps.getScreenshot,
+    });
+    expect(deps.page.on).toHaveBeenCalledWith('framenavigated', expect.any(Function));
+    expect(deps.page.on).toHaveBeenCalledWith('close', expect.any(Function));
+    session.stop(100);
+  });
+
+  it('stop() cleanly removes page listeners', () => {
+    const deps = mkComposedDeps();
+    const session = new PerceptionSession({ eventStream: deps.stream });
+    session.start(0, {
+      page: deps.page,
+      frameCapture: deps.frameCapture,
+      indexer: deps.indexer,
+      structuralPipeline: deps.structuralPipeline,
+      classifyByVlm: deps.classifyByVlm,
+      getScreenshot: deps.getScreenshot,
+    });
+    session.stop(100);
+    expect(deps.page.off).toHaveBeenCalledWith('framenavigated', expect.any(Function));
+    expect(deps.page.off).toHaveBeenCalledWith('close', expect.any(Function));
+  });
+
+  it('navigation event resets sessionStartMs and emits a navigation-reset tick', () => {
+    const deps = mkComposedDeps();
+    const session = new PerceptionSession({ eventStream: deps.stream });
+    session.start(0, {
+      page: deps.page,
+      frameCapture: deps.frameCapture,
+      indexer: deps.indexer,
+      structuralPipeline: deps.structuralPipeline,
+      classifyByVlm: deps.classifyByVlm,
+      getScreenshot: deps.getScreenshot,
+    });
+    // Find and invoke the framenavigated handler
+    const navHandler = deps.page.on.mock.calls.find((c: any[]) => c[0] === 'framenavigated')[1];
+    navHandler();
+    expect(deps.stream.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'perception-tick',
+        payload: expect.objectContaining({ tier: 'frame', cause: 'navigation-reset' }),
+      }),
+    );
+    session.stop(100);
+  });
+
+  it('page close auto-stops the session', () => {
+    const deps = mkComposedDeps();
+    const session = new PerceptionSession({ eventStream: deps.stream });
+    session.start(0, {
+      page: deps.page,
+      frameCapture: deps.frameCapture,
+      indexer: deps.indexer,
+      structuralPipeline: deps.structuralPipeline,
+      classifyByVlm: deps.classifyByVlm,
+      getScreenshot: deps.getScreenshot,
+    });
+    const closeHandler = deps.page.on.mock.calls.find((c: any[]) => c[0] === 'close')[1];
+    closeHandler();
+    expect(session.isRunning()).toBe(false);
   });
 });

--- a/tests/unit/pipelines/perception/types.test.ts
+++ b/tests/unit/pipelines/perception/types.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  PerceptionTier,
+  AnomalyReason,
+  PerceptionTickPayload,
+  PerceptionAnomalyPayload,
+  PerceptionEscalationPayload,
+  PerceptionIntentResultPayload,
+  TimelineEvent,
+} from '../../../../src/pipelines/temporal/collectors/types.js';
+import type { PerceptionSessionSummary } from '../../../../src/pipelines/perception/types.js';
+
+describe('PerceptionTier', () => {
+  it('accepts the three tier values', () => {
+    const tiers: PerceptionTier[] = ['frame', 'semantic', 'intent'];
+    expect(tiers).toHaveLength(3);
+  });
+});
+
+describe('AnomalyReason', () => {
+  it('accepts the v1 reason', () => {
+    const r: AnomalyReason = 'mutation-outside-animation';
+    expect(r).toBe('mutation-outside-animation');
+  });
+});
+
+describe('PerceptionTickPayload', () => {
+  it('accepts each cause value', () => {
+    const causes: Array<PerceptionTickPayload['cause']> = ['keyframe', 'heartbeat', 'escalation', 'navigation-reset'];
+    const payloads = causes.map((cause) => ({ tier: 'frame' as const, cause }));
+    expect(payloads).toHaveLength(4);
+  });
+});
+
+describe('PerceptionAnomalyPayload', () => {
+  it('accepts a full anomaly shape', () => {
+    const p: PerceptionAnomalyPayload = {
+      tier: 'frame',
+      reason: 'mutation-outside-animation',
+      detail: { mutationCount: 3, targetNodeIds: ['dom-1', 'dom-2'] },
+    };
+    expect(p.detail.mutationCount).toBe(3);
+  });
+});
+
+describe('PerceptionEscalationPayload', () => {
+  it('accepts a frame→semantic escalation', () => {
+    const p: PerceptionEscalationPayload = {
+      from: 'frame',
+      to: 'semantic',
+      reason: 'mutation-outside-animation',
+      regions: [{ nodeId: 'dom-1', bbox: { x: 0, y: 0, w: 100, h: 50 } }],
+    };
+    expect(p.regions).toHaveLength(1);
+  });
+});
+
+describe('PerceptionIntentResultPayload', () => {
+  it('accepts a complete intent result', () => {
+    const p: PerceptionIntentResultPayload = {
+      region: { nodeId: 'dom-1', bbox: { x: 0, y: 0, w: 100, h: 50 } },
+      classification: 'AnimatedCounter',
+      classificationSource: 'vlm',
+      durationMs: 873,
+    };
+    expect(p.classification).toBe('AnimatedCounter');
+  });
+});
+
+describe('TimelineEvent<perception-*>', () => {
+  it('perception-tick typechecks via PayloadFor mapping', () => {
+    const e: TimelineEvent<'perception-tick'> = {
+      id: 'evt-1', type: 'perception-tick', timestamp: 0,
+      payload: { tier: 'frame', cause: 'keyframe' },
+    };
+    expect(e.type).toBe('perception-tick');
+  });
+
+  it('perception-anomaly typechecks', () => {
+    const e: TimelineEvent<'perception-anomaly'> = {
+      id: 'evt-2', type: 'perception-anomaly', timestamp: 0,
+      payload: { tier: 'frame', reason: 'mutation-outside-animation', detail: { mutationCount: 1, targetNodeIds: ['x'] } },
+    };
+    expect(e.type).toBe('perception-anomaly');
+  });
+
+  it('perception-escalation typechecks', () => {
+    const e: TimelineEvent<'perception-escalation'> = {
+      id: 'evt-3', type: 'perception-escalation', timestamp: 0,
+      payload: { from: 'frame', to: 'semantic', reason: 'mutation-outside-animation', regions: [] },
+    };
+    expect(e.type).toBe('perception-escalation');
+  });
+
+  it('perception-intent-result typechecks', () => {
+    const e: TimelineEvent<'perception-intent-result'> = {
+      id: 'evt-4', type: 'perception-intent-result', timestamp: 0,
+      payload: {
+        region: { nodeId: 'x', bbox: { x: 0, y: 0, w: 10, h: 10 } },
+        classification: 'X',
+        classificationSource: 'vlm',
+        durationMs: 100,
+      },
+    };
+    expect(e.type).toBe('perception-intent-result');
+  });
+});
+
+describe('PerceptionSessionSummary', () => {
+  it('accepts a complete summary shape', () => {
+    const s: PerceptionSessionSummary = {
+      startedAt: 0,
+      durationMs: 5000,
+      tickCounts: { frame: 12, semantic: 3, intent: 1 },
+      averageCadenceMs: { frame: 100, semantic: 1500, intent: null },
+      targetCadenceMs: { frame: 16, semantic: 200, intent: 1000 },
+      anomalyCount: 2,
+      anomaliesByReason: { 'mutation-outside-animation': 2 },
+      escalationCount: 3,
+      intentResultCount: 1,
+      vlmCalls: { count: 1, estimatedDollars: 0.02 },
+    };
+    expect(s.anomalyCount).toBe(2);
+  });
+
+  it('accepts a summary with null averageCadenceMs for an unused tier', () => {
+    const s: PerceptionSessionSummary = {
+      startedAt: 0, durationMs: 100,
+      tickCounts: { frame: 0, semantic: 0, intent: 0 },
+      averageCadenceMs: { frame: null, semantic: null, intent: null },
+      targetCadenceMs: { frame: 16, semantic: 200, intent: 1000 },
+      anomalyCount: 0,
+      anomaliesByReason: { 'mutation-outside-animation': 0 },
+      escalationCount: 0,
+      intentResultCount: 0,
+      vlmCalls: { count: 0 },
+    };
+    expect(s.tickCounts.frame).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Ships sub-projects #7 (Hierarchical loops at fixed rates) + #8 (Anomaly-triggered attention) as a merged scope. Three autonomous loops (frame / semantic / intent) communicate via an in-session `EventEmitter`; loops are idle by default and wake on heartbeat-with-pending-work or escalation from a faster loop.
- v1 anomaly trigger: `mutation-outside-animation`. `FrameLoop` installs a page-side `MutationObserver` for per-node mutations, tracks active CSS animations via `TemporalEventStream` subscription, calls the pure detector on each keyframe.
- New MCP tools (`start_perception`, `stop_perception`, `get_perception_session`), new event types on the timeline (`perception-tick`, `perception-anomaly`, `perception-escalation`, `perception-intent-result`), and a `perception-session` Claude skill for inspection workflows.

## Design + plan
- Spec: `docs/superpowers/specs/2026-05-17-perception-loops-design.md`
- Plan: `docs/superpowers/plans/2026-05-17-perception-loops.md` (11 TDD-structured tasks)

## Architectural notes
- `TemporalEventStream` now extends `EventEmitter` and emits on every `push()` so the loops can subscribe in real time. Additive change — no existing consumer reads `'event'`.
- Frame escalation payload's `regions[*].nodeId` are synthetic `mut-N` IDs that don't correlate with structural-pipeline `dom-N` IDs. By design, `SemanticLoop` ignores them and does a full re-scan via `Indexer.run()`; the IDs remain on the timeline as inspection metadata.
- `start_perception` auto-starts watch (perception needs keyframes). `stop_perception` does NOT auto-stop watch — keyframe capture stays alive for non-perception consumers. Documented in tool descriptions.

## Test posture
- **498 unit tests** + 2 real-browser integration tests pass; `pnpm exec tsc --noEmit` clean.
- Real-browser e2e: button click → `setTimeout` text mutation → frame keyframe → assert anomaly chain. Plus a CSS-animation-suppression negative case.

## Review history

This PR went through three review passes. Each pass dispatched three specialist reviewers in parallel (code review, silent-failure hunting, test-coverage analysis); full reports are checked in under `.review/` (`pr10-*` for pass 1, `pass2/*` for pass 2, `pass3/*` for pass 3).

### Pass 0 fixes (commit `4e53077`)
After the initial review, three critical + three important issues were fixed in one commit:
1. `FrameLoop` reinstalls its page-side observer on `framenavigated`
2. WeakMap dispatcher pattern (matches `MutationCollector`) so second-session mutations route correctly
3. `PerceptionSession.start()` is now async; loops are awaited
4. `get_timeline` Zod enum updated to include all current event types
5. `IntentLoop` guards `recordIntentResult` / `recordTick` with `this.running` so in-flight VLM calls don't pollute a stopped session's summary
6. `SemanticLoop` uses discriminated-union narrowing (`field.name === null`) instead of `as any`

### Pass 1 fixes (8 commits, `2c5ffa0..0735f85`)
Pass-1 review found 4 critical + 5 important issues — every fix landed via strict TDD (RED test that captured the bug → GREEN minimal fix → verify):
- `2c5ffa0` — **C3+I5** catch framenavigated reinstall errors + add the two regression locks for the 4e53077 fixes (#1 + #2 had zero coverage)
- `71e2ac8` — **C2** FrameLoop `stopped` flag (parity with semantic + intent loops)
- `413e7d4` — **C1** IntentLoop drain guard + log silent screenshot failures
- `a5ab9da` — **C4** `start_perception` throws clearly when no event stream is wired
- `d66e49c` — **I1** log `onPageClose` stop() errors instead of swallowing
- `53ef82a` — **I2** preserve VLM error stack + track `vlmCalls.errorCount`
- `df44ade` — **I3** SemanticLoop tick try/catch + clear `wakeTimer` on stop
- `0735f85` — **I4** exclude `navigation-reset` from `averageCadenceMs` aggregation

### Pass 2 fixes (6 commits, `f3aee18..358d483`)
Pass-2 review found 2 critical + 4 important issues — all siblings of the pass-1 fixes themselves:
- `f3aee18` — **P2-C1** IntentLoop circuit breaker for screenshot perma-throw (bounds log volume to threshold + suppression notice)
- `0dacda2` — **P2-C2** session `stop()` made fault-tolerant via `safeRun` wrapper + aggregated error
- `46d570b` — **P2-H1+H2+I2** SemanticLoop `inFlight` flag, `recordTick` moved inside try (no more ghost ticks), `scheduleWake` coalesces rapid escalates (no timer leak)
- `7aff81a` — **P2-I1** gate `recordVlmError` on `this.running` (asymmetric with C1 fix)
- `28839f6` — **P2-N1** discriminate known Playwright races (TargetClosed → WARN) from genuinely unexpected errors (→ ERROR with UNEXPECTED prefix)
- `358d483` — test-only commit closing pass-2 coverage gaps (G3-G6)

## Known follow-ups (captured in roadmap)
- `TransitionCollector` to catch CSS `transition` (currently false-negatives)
- Spatial gating for animations on unrelated subtrees
- Surface live queue size for `pendingVlm` (same shape of fix `get_component_index` needs)
- Cost estimation for `vlmCalls.estimatedDollars`

## Test plan
- [ ] Pull the branch, run `pnpm install && pnpm exec tsc --noEmit && pnpm exec vitest run`
- [ ] Run the perception e2e: `pnpm exec vitest run tests/integration/perception/`
- [ ] Manually exercise via MCP: navigate to a real page → `start_perception` → drive an action → `stop_perception` → inspect the summary; events should appear via `get_timeline` filtered to `perception-*` types
- [ ] Try the `perception-session` Claude skill on a workflow
