### PR TITLE
fix(sidecar): pin OmniParser deps to patched versions (63→16 CVEs)

### DIFF
--- a/sidecar/omniparser/requirements.txt
+++ b/sidecar/omniparser/requirements.txt
@@ -3,7 +3,10 @@ torchvision
 ultralytics
 transformers
 fastapi
+# Security floor — pin to avoid known CVEs even if `fastapi` resolves an older
+# transitive starlette. See `.review/security/` for the audit run.
+starlette>=1.0.1            # PYSEC-2026-161 (BadHost: request.url.path poisoning)
+python-multipart>=0.0.27    # CVE-2026-40347 + CVE-2026-42561 (multipart DoS)
 uvicorn
-python-multipart
 pillow
 huggingface_hub

--- a/sidecar/omniparser/requirements.txt
+++ b/sidecar/omniparser/requirements.txt
@@ -1,12 +1,39 @@
 torch
 torchvision
 ultralytics
-transformers
 fastapi
-# Security floor — pin to avoid known CVEs even if `fastapi` resolves an older
-# transitive starlette. See `.review/security/` for the audit run.
-starlette>=1.0.1            # PYSEC-2026-161 (BadHost: request.url.path poisoning)
-python-multipart>=0.0.27    # CVE-2026-40347 + CVE-2026-42561 (multipart DoS)
 uvicorn
-pillow
 huggingface_hub
+
+# ---------------------------------------------------------------------------
+# Security floors — pin to drop known CVEs flagged by `pip-audit`. Floors
+# only (no upper bound) so future bumps are picked up automatically. Each
+# line carries the advisory + the version that fixes it.
+# ---------------------------------------------------------------------------
+
+# FastAPI ecosystem (direct attack surface — multipart UploadFile endpoint):
+starlette>=1.0.1            # PYSEC-2026-161  (BadHost: request.url.path poisoning)
+python-multipart>=0.0.27    # CVE-2026-40347 + CVE-2026-42561 (multipart DoS)
+
+# Image processing (user-controlled input → high priority):
+pillow>=12.2.0              # PYSEC-2026-165, CVE-2026-25990/40192/42309/42310/42311
+transformers>=4.53.0,<5     # PYSEC-2024-227/228/229, CVE-2024-12720,
+                            # CVE-2025-1194/3263/3264/3777/3933/5197
+
+# Transitive deps in the venv that pip-audit flagged:
+filelock>=3.20.3            # CVE-2025-68146, CVE-2026-22701
+idna>=3.15                  # CVE-2026-45409
+pygments>=2.20.0            # CVE-2026-4539
+requests>=2.33.0            # CVE-2026-25645   (insecure temp-file reuse)
+setuptools>=78.1.1          # CVE-2024-6345, PYSEC-2022-43012, PYSEC-2025-49
+urllib3>=2.7.0              # PYSEC-2026-141, PYSEC-2026-142
+
+# ---------------------------------------------------------------------------
+# Accepted-risk (not fixable on this venv — documented, not silenced):
+# - torch 2.2.2: 14 CVEs (fixes in 2.5.0+). No newer wheels for x86_64 macOS
+#   per project memory — pinned by hardware constraint. Mitigation:
+#   `weights_only=True` on every `torch.load`, never load untrusted weights.
+# - transformers PYSEC-2025-217: no fix version published upstream.
+# - transformers CVE-2026-1839: only fixed in 5.0.0rc3 (major bump that
+#   would require re-validating Florence-2 model loading). Defer.
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`pip-audit` flagged **63 CVEs across 12 packages** in the OmniParser sidecar venv. This PR pins floors that drop that to **16 CVEs across 2 packages** (all in `torch` / `transformers`, documented as accepted-risk because they need wheels or major bumps the project can't yet absorb).

The sidecar exposes a FastAPI `UploadFile` endpoint, so the FastAPI + image-processing stack is on the live attack surface.

## What's patched

| Category | Pin | Advisories |
|---|---|---|
| **FastAPI ecosystem** | `starlette >= 1.0.1` | **PYSEC-2026-161** — *BadHost*: missing Host header validation poisons `request.url.path`, bypassing path-based security checks |
| | `python-multipart >= 0.0.27` | **CVE-2026-40347** (large multipart preamble DoS), **CVE-2026-42561** (unbounded part-header DoS) |
| **Image processing** | `pillow >= 12.2.0` | PYSEC-2026-165, CVE-2026-25990 / 40192 / 42309 / 42310 / 42311 |
| **HF stack** | `transformers >= 4.53.0, < 5` | PYSEC-2024-227 / 228 / 229, CVE-2024-12720, CVE-2025-1194 / 3263 / 3264 / 3777 / 3933 / 5197 (held to 4.x to avoid Florence-2 regression) |
| **Transitive deps** | `filelock >= 3.20.3` | CVE-2025-68146, CVE-2026-22701 |
| | `idna >= 3.15` | CVE-2026-45409 |
| | `pygments >= 2.20.0` | CVE-2026-4539 |
| | `requests >= 2.33.0` | CVE-2026-25645 (insecure temp-file reuse) |
| | `setuptools >= 78.1.1` | CVE-2024-6345, PYSEC-2022-43012, PYSEC-2025-49 |
| | `urllib3 >= 2.7.0` | PYSEC-2026-141, PYSEC-2026-142 |

Pins are floors only — `pip` resolves freely above. FastAPI 0.135.1 + starlette 1.1.0 + python-multipart 0.0.29 + transformers 4.57.6 all install and import together in the current venv.

## Accepted risk (documented inline in requirements.txt)

| Package | CVEs | Why not fixed here |
|---|---|---|
| `torch 2.2.2` | 14 CVEs (fix in 2.5+) | No newer wheels for x86_64 macOS — pinned by hardware. Mitigation: `weights_only=True` on every `torch.load`, never load untrusted weights |
| `transformers` | PYSEC-2025-217 | No fix version published upstream |
| `transformers` | CVE-2026-1839 | Only fixed in 5.0.0rc3 — major version bump requires re-validating Florence-2 loading; deferred |

## Verification

```
Before: Found 63 known vulnerabilities in 12 packages
After:  Found 16 known vulnerabilities in 2 packages
```

Both flagged packages (`torch`, `transformers`) appear in the audit only for items above; nothing new introduced.

## Test plan

- [ ] `cd sidecar/omniparser && .venv/bin/python -m pip install -r requirements.txt --upgrade`
- [ ] `.venv/bin/python -m pip_audit` — confirm only the 16 known-accepted items remain
- [ ] Smoke the sidecar: `uvicorn main:app --port 8000` and POST a multipart screenshot
- [ ] If Florence-2 captions look off, regress transformers in 0.5-minor steps and rerun smoke
