### PR TITLE
fix(mcp): resolve uipe-vision sidecar via workspace root, not cwd

### DIFF
--- a/packages/core/bench/optical-flow-eval.ts
+++ b/packages/core/bench/optical-flow-eval.ts
@@ -1,7 +1,9 @@
-import { resolve } from 'node:path';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { existsSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import { EventEmitter } from 'node:events';
+import { resolveFlowBinaryPath } from '../src/utils/flow-binary.js';
 import { FlowProducer } from '../src/pipelines/temporal/producers/optical-flow.js';
 import { FlowCollector } from '../src/pipelines/temporal/collectors/optical-flow.js';
 import { TemporalEventStream } from '../src/pipelines/temporal/event-stream.js';
@@ -113,7 +115,10 @@ function percentile(arr: number[], p: number): number {
 }
 
 async function main(): Promise<void> {
-  const bin = resolve(process.cwd(), 'target/release/uipe-vision');
+  const bin = resolveFlowBinaryPath(
+    process.env,
+    dirname(fileURLToPath(import.meta.url)),
+  );
   if (!existsSync(bin)) {
     console.error(`Binary missing: ${bin}. Run 'pnpm run build:rust' first.`);
     process.exit(1);

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { resolve } from 'node:path';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { existsSync } from 'node:fs';
 import { EventEmitter } from 'node:events';
 import { BrowserRuntime } from '../browser/runtime.js';
@@ -24,6 +25,7 @@ import {
 import { FlowProducer } from '../pipelines/temporal/producers/optical-flow.js';
 import { FlowCollector } from '../pipelines/temporal/collectors/optical-flow.js';
 import { createLogger } from '../utils/logger.js';
+import { resolveFlowBinaryPath } from '../utils/flow-binary.js';
 import type { Collector } from '../pipelines/temporal/collectors/types.js';
 import { makeGetTimelineTool } from './tools/get-timeline.js';
 import { ComponentIndexStore } from '../pipelines/component-index/store.js';
@@ -40,8 +42,10 @@ import {
 } from './tools/perception.js';
 
 const log = createLogger('mcp-server');
-const FLOW_BINARY_PATH = process.env.UIPE_FLOW_BINARY ??
-  resolve(process.cwd(), 'target/release/uipe-vision');
+const FLOW_BINARY_PATH = resolveFlowBinaryPath(
+  process.env,
+  dirname(fileURLToPath(import.meta.url)),
+);
 
 export interface ServerConfig {
   visual?: VisualPipelineConfig;

--- a/packages/core/src/utils/flow-binary.ts
+++ b/packages/core/src/utils/flow-binary.ts
@@ -1,0 +1,43 @@
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const WORKSPACE_MARKER = 'pnpm-workspace.yaml';
+const BINARY_REL = 'target/release/uipe-vision';
+
+type ExistsFn = (path: string) => boolean;
+
+/**
+ * Walk up from `startDir` until a directory containing the workspace marker is
+ * found. Returns that directory, or null if the filesystem root is reached
+ * first. Used to locate the repo root independent of cwd and of whether we're
+ * running from `src/` (tsx) or `dist/` (compiled), whose depths differ.
+ */
+export function findWorkspaceRoot(
+  startDir: string,
+  exists: ExistsFn = existsSync,
+): string | null {
+  let dir = startDir;
+  for (;;) {
+    if (exists(resolve(dir, WORKSPACE_MARKER))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null; // reached filesystem root
+    dir = parent;
+  }
+}
+
+/**
+ * Resolve the Rust optical-flow sidecar binary. Precedence:
+ *   1. `UIPE_FLOW_BINARY` env override (set explicitly in the Fly container).
+ *   2. `<workspace-root>/target/release/uipe-vision`, located by walking up from
+ *      the caller's module dir to the workspace marker.
+ *   3. Fallback to a cwd-relative path (legacy behavior) if no root is found.
+ */
+export function resolveFlowBinaryPath(
+  env: NodeJS.ProcessEnv,
+  startDir: string,
+  exists: ExistsFn = existsSync,
+): string {
+  if (env.UIPE_FLOW_BINARY) return env.UIPE_FLOW_BINARY;
+  const root = findWorkspaceRoot(startDir, exists);
+  return resolve(root ?? process.cwd(), BINARY_REL);
+}

--- a/packages/core/tests/unit/utils/flow-binary.test.ts
+++ b/packages/core/tests/unit/utils/flow-binary.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findWorkspaceRoot,
+  resolveFlowBinaryPath,
+} from '../../../src/utils/flow-binary.js';
+
+// Simulated monorepo layout. The workspace marker (pnpm-workspace.yaml) and the
+// Rust target/ dir both live at the repo root. The engine source lives at
+// packages/core/src/..., and compiles to packages/core/dist/src/... — a depth
+// that differs from the source by one level. The whole point of the fix is that
+// binary resolution must be independent of BOTH the cwd and that depth delta.
+const ROOT = '/repo';
+const MARKER = '/repo/pnpm-workspace.yaml';
+const SRC_DIR = '/repo/packages/core/src/mcp'; // tsx (dev/bench) import.meta.url dir
+const DIST_DIR = '/repo/packages/core/dist/src/mcp'; // compiled import.meta.url dir
+const EXPECTED = '/repo/target/release/uipe-vision';
+
+const onlyMarker = (p: string) => p === MARKER;
+
+describe('findWorkspaceRoot', () => {
+  it('walks up multiple levels to the dir containing the marker', () => {
+    expect(findWorkspaceRoot(SRC_DIR, onlyMarker)).toBe(ROOT);
+    expect(findWorkspaceRoot(DIST_DIR, onlyMarker)).toBe(ROOT);
+  });
+
+  it('returns the start dir when the marker is already there', () => {
+    expect(findWorkspaceRoot(ROOT, onlyMarker)).toBe(ROOT);
+  });
+
+  it('returns null when no marker exists up to the filesystem root', () => {
+    expect(findWorkspaceRoot(SRC_DIR, () => false)).toBeNull();
+  });
+});
+
+describe('resolveFlowBinaryPath', () => {
+  it('prefers the UIPE_FLOW_BINARY env override and skips the walk-up', () => {
+    const path = resolveFlowBinaryPath(
+      { UIPE_FLOW_BINARY: '/custom/uipe-vision' },
+      SRC_DIR,
+      () => {
+        throw new Error('exists must not be consulted when env override is set');
+      },
+    );
+    expect(path).toBe('/custom/uipe-vision');
+  });
+
+  it('resolves the repo-root binary regardless of source vs compiled depth', () => {
+    // The bug: a cwd- or fixed-offset-based path drifts between dev and prod.
+    // Both call sites must land on the same repo-root binary.
+    expect(resolveFlowBinaryPath({}, SRC_DIR, onlyMarker)).toBe(EXPECTED);
+    expect(resolveFlowBinaryPath({}, DIST_DIR, onlyMarker)).toBe(EXPECTED);
+  });
+
+  it('falls back to a cwd-relative path when no workspace root is found', () => {
+    const path = resolveFlowBinaryPath({}, SRC_DIR, () => false);
+    expect(path.endsWith('target/release/uipe-vision')).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Locate the Rust optical-flow sidecar (`target/release/uipe-vision`) by walking up from `import.meta.url` to the `pnpm-workspace.yaml` marker, instead of `resolve(process.cwd(), ...)`.

## Why

The cwd path only worked when the process was invoked from the repo root. After the Phase-1 monorepo move the engine runs from `packages/core/` and `start.sh` doesn't `cd`, so cwd is wherever the user invoked from. A *fixed* `import.meta.url` offset would also be wrong because the `src/` (tsx) and `dist/` (compiled) depths differ by one level — the walk-up is invariant to both. Matters for the Phase-4 Fly deploy where cwd is container-defined.

`UIPE_FLOW_BINARY` still takes precedence (set explicitly in the Fly container); falls back to a cwd-relative path when no workspace root is found. Applied to both the MCP server and the optical-flow bench.

## Tests

New `flow-binary.test.ts` (6 tests) with an injected `exists` fn, including the source-vs-compiled depth-invariance the cwd path lacked. `tsc --noEmit` clean; bench typechecked separately (it's outside the default tsc program).

Closes #16