### PR TITLE
test(core): isolate real-browser tests so the suite stops flaking

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,8 @@
     "dev": "tsx src/index.ts",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:all": "vitest run && vitest run --config vitest.integration.config.ts",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src tests --ext .ts",
     "setup:flow-model": "pnpm exec tsx scripts/download-flow-model.ts",

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,10 +1,15 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
     include: ['tests/**/*.test.ts'],
+    // Real-browser (Playwright) integration + e2e tests are excluded from the
+    // default run. Their animation-timing assertions miss their event window
+    // when test files run concurrently and saturate CPU (#15). Run them serially
+    // via vitest.integration.config.ts (`pnpm test:integration`).
+    exclude: [...configDefaults.exclude, 'tests/integration/**', 'tests/e2e/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],

--- a/packages/core/vitest.integration.config.ts
+++ b/packages/core/vitest.integration.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+// Real-browser (Playwright) integration + e2e tests (tests/integration, tests/e2e).
+// Run serially: concurrent test files saturate CPU on the Intel Mac, so
+// animation-timing assertions miss their event window under contention (#15).
+// fileParallelism:false runs one test file at a time, eliminating the race.
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/integration/**/*.test.ts', 'tests/e2e/**/*.test.ts'],
+    fileParallelism: false,
+    testTimeout: 30000,
+  },
+});


### PR DESCRIPTION
## What

Split the vitest suites so the default `vitest run` excludes real-browser tests (`tests/integration` + `tests/e2e`) and a dedicated `vitest.integration.config.ts` runs them serially (`fileParallelism: false`). Adds `test:integration` + `test:all` scripts.

## Why

The `animation-verifier` Playwright test (and other real-browser tests) miss their `animation-end` event window when vitest runs test files concurrently and saturates CPU on the Intel Mac. It passes 4/4 in isolation; only the full parallel run flaked. Serializing the real-browser tier removes the CPU contention at the root, and the default run (the unit gate) is now deterministic and parallel.

## Tests

Default run = unit-only (500, zero integration/e2e collected). Serial integration+e2e run twice, identical: 10 passed | 1 skipped (the 1 skip is a pre-existing external-service test), `animation-verifier` 4/4 both times.

Closes #15