### PR TITLE
fix(perception): pass-3 review polish (observability, error causes, nav classification)

### DIFF
--- a/packages/core/src/pipelines/perception/frame-loop.ts
+++ b/packages/core/src/pipelines/perception/frame-loop.ts
@@ -92,7 +92,11 @@ export class FrameLoop {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       const stack = err instanceof Error ? err.stack : String(err);
+      // P3-N1: prefer the structured error name (stable across Playwright
+      // versions + locales); fall back to the message regex only for errors
+      // that don't set a recognizable name (older Playwright, destroyed-context).
       const isKnownPlaywrightRace =
+        (err instanceof Error && err.name === 'TargetClosedError') ||
         /target.*closed/i.test(msg) ||
         /execution context.*destroyed/i.test(msg);
       if (isKnownPlaywrightRace) {

--- a/packages/core/src/pipelines/perception/intent-loop.ts
+++ b/packages/core/src/pipelines/perception/intent-loop.ts
@@ -104,6 +104,30 @@ export class IntentLoop {
     }
   }
 
+  /** P3-I1/I2: handle a screenshot-acquisition failure uniformly for both the
+   *  throw and null paths. Counts it in the session summary (gated on running,
+   *  mirroring recordVlmError), advances the shared suppression streak, bounds
+   *  per-failure log volume (P2-C1 circuit breaker), and drops the pending
+   *  queue. `detail` is supplied by the caller and must be read BEFORE pending
+   *  is cleared. */
+  private handleScreenshotFailure(
+    level: 'error' | 'warn',
+    message: string,
+    detail: Record<string, unknown>,
+  ): void {
+    if (this.running) this.session.recordScreenshotError();
+    this.screenshotErrorStreak += 1;
+    if (this.screenshotErrorStreak <= SCREENSHOT_ERROR_LOG_THRESHOLD) {
+      logger[level](message, { ...detail, streak: this.screenshotErrorStreak });
+    } else if (this.screenshotErrorStreak === SCREENSHOT_ERROR_LOG_THRESHOLD + 1) {
+      logger[level](
+        'IntentLoop: screenshot provider repeatedly failing; suppressing further per-failure logs until next success',
+        { streak: this.screenshotErrorStreak },
+      );
+    }
+    this.pending = [];
+  }
+
   private async drain(): Promise<void> {
     // C1 belt-and-suspenders: skip even if a stale escalate kicked off a
     // drain between `running = false` and `internalEmitter.off(...)` in stop().
@@ -124,33 +148,25 @@ export class IntentLoop {
       try {
         screenshot = await this.getScreenshot();
       } catch (err) {
-        // P2-C1: bound log volume so a perma-throwing screenshot provider
-        // doesn't spam ERROR per escalation for the rest of the session.
-        // Below threshold → normal error log. AT threshold+1 → one "suppressing"
-        // notice. Above → silent (still drops pending).
-        this.screenshotErrorStreak += 1;
-        if (this.screenshotErrorStreak <= SCREENSHOT_ERROR_LOG_THRESHOLD) {
-          logger.error('IntentLoop: screenshot provider threw; dropping pending queue', {
-            error: err instanceof Error ? err.stack : String(err),
-            dropped: this.pending.length,
-            streak: this.screenshotErrorStreak,
-          });
-        } else if (this.screenshotErrorStreak === SCREENSHOT_ERROR_LOG_THRESHOLD + 1) {
-          logger.error(
-            'IntentLoop: screenshot provider repeatedly throwing; suppressing further per-failure logs until next success',
-            { streak: this.screenshotErrorStreak },
-          );
-        }
-        this.pending = [];
+        // P2-C1 + P3-I1/I2: count the failure, bound per-failure logs so a
+        // perma-throwing provider doesn't spam ERROR for the rest of the
+        // session, and drop pending. dropped count is read before clearing.
+        this.handleScreenshotFailure(
+          'error',
+          'IntentLoop: screenshot provider threw; dropping pending queue',
+          { error: err instanceof Error ? err.stack : String(err), dropped: this.pending.length },
+        );
         return;
       }
       if (!screenshot) {
-        // Can't classify without a screenshot — drop all pending. Log so the
-        // failure is visible; previously this branch was silent.
-        logger.warn('IntentLoop: screenshot provider returned null; dropping pending queue', {
-          dropped: this.pending.length,
-        });
-        this.pending = [];
+        // P3-I2: a null screenshot is a failure too — route it through the same
+        // handler so it shares the suppression streak (previously null neither
+        // incremented nor reset the streak, making the signal misleading).
+        this.handleScreenshotFailure(
+          'warn',
+          'IntentLoop: screenshot provider returned null; dropping pending queue',
+          { dropped: this.pending.length },
+        );
         return;
       }
       // Screenshot succeeded — reset the error streak so future failures

--- a/packages/core/src/pipelines/perception/session.ts
+++ b/packages/core/src/pipelines/perception/session.ts
@@ -176,7 +176,11 @@ export class PerceptionSession {
       const summary = errors
         .map(({ label, err }) => `${label}: ${err instanceof Error ? err.message : String(err)}`)
         .join('; ');
-      throw new Error(`PerceptionSession.stop() partial failure: ${summary}`);
+      // P3-I3: keep the grep-friendly label summary in the message, but carry
+      // the underlying {label, err} records via `cause` so each step's original
+      // type and stack survive — onPageClose's logger can then point at the real
+      // failure site instead of this throw line. (Error cause: Node 16+/ES2022.)
+      throw new Error(`PerceptionSession.stop() partial failure: ${summary}`, { cause: errors });
     }
   }
 

--- a/packages/core/src/pipelines/perception/session.ts
+++ b/packages/core/src/pipelines/perception/session.ts
@@ -95,6 +95,7 @@ export class PerceptionSession {
   private intentResultCount = 0;
   private vlmCallCount = 0;
   private vlmErrorCount = 0;
+  private screenshotErrorCount = 0;
 
   constructor(options: PerceptionSessionOptions) {
     this.stream = options.eventStream;
@@ -272,6 +273,14 @@ export class PerceptionSession {
     this.vlmErrorCount += 1;
   }
 
+  /** P3-I1: mirror recordVlmError for screenshot-acquisition failures (throw
+   *  or null) in the IntentLoop. Always incremented — independent of the loop's
+   *  per-failure log circuit breaker — so the summary reflects a silently
+   *  degraded session instead of looking idle. */
+  recordScreenshotError(): void {
+    this.screenshotErrorCount += 1;
+  }
+
   getSummary(): PerceptionSessionSummary {
     const now = this.state === 'running' ? Date.now() : this.stoppedAt;
     const durationMs = this.state === 'idle' ? 0 : now - this.startedAt;
@@ -306,6 +315,7 @@ export class PerceptionSession {
         count: this.vlmCallCount,
         ...(this.vlmErrorCount > 0 ? { errorCount: this.vlmErrorCount } : {}),
       },
+      ...(this.screenshotErrorCount > 0 ? { screenshotErrors: this.screenshotErrorCount } : {}),
     };
   }
 }

--- a/packages/core/src/pipelines/perception/types.ts
+++ b/packages/core/src/pipelines/perception/types.ts
@@ -11,4 +11,8 @@ export interface PerceptionSessionSummary {
   escalationCount: number;
   intentResultCount: number;
   vlmCalls: { count: number; errorCount?: number; estimatedDollars?: number };
+  /** P3-I1: count of screenshot-acquisition failures (throw or null) in the
+   *  IntentLoop. Absent when none occurred; present so a perma-broken-screenshot
+   *  session is distinguishable from an idle one in post-mortem. */
+  screenshotErrors?: number;
 }

--- a/packages/core/tests/unit/pipelines/perception/frame-loop.test.ts
+++ b/packages/core/tests/unit/pipelines/perception/frame-loop.test.ts
@@ -384,6 +384,34 @@ describe('FrameLoop page-side observer', () => {
     }
   });
 
+  it('classifies a TargetClosedError by err.name even when the message does not match the race regex (P3-N1)', async () => {
+    const { session, page, loop } = setupWithPage({ warmupMs: 0 });
+    await session.start(0);
+    await loop.start();
+    // A real Playwright TargetClosedError whose message text does NOT contain
+    // "target closed" / "execution context destroyed" — those strings drift
+    // across Playwright versions + locales, so only err.name reliably IDs it.
+    const targetClosed = new Error('Protocol error (Runtime.callFunctionOn): Session closed.');
+    targetClosed.name = 'TargetClosedError';
+    page.evaluate.mockRejectedValueOnce(targetClosed);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      page.emit('framenavigated');
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      const warned = logSpy.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('[WARN]'));
+      const errored = logSpy.mock.calls.some((c) => typeof c[0] === 'string' && c[0].includes('[ERROR]'));
+      // Known race → WARN, not a false-alarm ERROR.
+      expect(warned).toBe(true);
+      expect(errored).toBe(false);
+    } finally {
+      logSpy.mockRestore();
+      loop.stop();
+    }
+  });
+
   it('framenavigated reinstall errors are caught and logged, not unhandled rejections (C3 fix)', async () => {
     const { session, page, loop } = setupWithPage({ warmupMs: 0 });
     await session.start(0);

--- a/packages/core/tests/unit/pipelines/perception/intent-loop.test.ts
+++ b/packages/core/tests/unit/pipelines/perception/intent-loop.test.ts
@@ -459,4 +459,102 @@ describe('IntentLoop', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(classify).not.toHaveBeenCalled();
   });
+
+  it('counts every screenshot failure in summary.screenshotErrors, even past the log gate (P3-I1)', async () => {
+    const { session, stream } = mkSession();
+    await session.start(0);
+    const classify = vi.fn(async () => 'X');
+    const getScreenshot = vi.fn(async () => { throw new Error('target closed'); });
+    const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      loop.start();
+      // Fire 7 escalations (> the log threshold of 3) against a perma-throwing
+      // screenshot provider. The per-failure log is bounded by the circuit
+      // breaker, but the summary metric must count ALL of them — a permanently
+      // broken-screenshot session must not look identical to an idle one.
+      for (let i = 0; i < 7; i++) {
+        session.internalEmitter.emit('escalate', {
+          from: 'semantic',
+          regions: [{ nodeId: `n-${i}`, bbox: { x: 0, y: 0, w: 10, h: 10 } }],
+        });
+        await new Promise((r) => setTimeout(r, 0));
+      }
+      expect(session.getSummary().screenshotErrors).toBe(7);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('treats a null screenshot as a streak failure: bounds null-path log volume and counts it (P3-I2)', async () => {
+    const { session, stream } = mkSession();
+    await session.start(0);
+    const classify = vi.fn(async () => 'X');
+    const getScreenshot = vi.fn(async () => null);
+    const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      loop.start();
+      // 20 escalations against a perma-null screenshot. Before the fix the null
+      // path logged WARN every single time (unbounded) and never touched the
+      // streak. After the fix it shares the throw path's suppression streak, so
+      // log volume is bounded and every failure is counted.
+      for (let i = 0; i < 20; i++) {
+        session.internalEmitter.emit('escalate', {
+          from: 'semantic',
+          regions: [{ nodeId: `n-${i}`, bbox: { x: 0, y: 0, w: 10, h: 10 } }],
+        });
+        await new Promise((r) => setTimeout(r, 0));
+      }
+      const screenshotLogs = logSpy.mock.calls.filter((c) => {
+        const [prefix, msg] = c;
+        return typeof prefix === 'string' && typeof msg === 'string' && /screenshot/i.test(msg);
+      });
+      expect(screenshotLogs.length).toBeLessThanOrEqual(5);
+      expect(session.getSummary().screenshotErrors).toBe(20);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('resets the screenshot error streak on a successful screenshot so later failures log again (test gap A)', async () => {
+    const { session, stream } = mkSession();
+    await session.start(0);
+    const classify = vi.fn(async () => 'X');
+    // Sequence: throw x4 (exhausts threshold=3 + the suppression notice, so a
+    // 5th would be silent), then ONE success (call 5) which must reset the
+    // streak, then throw again (call 6) which must log at ERROR afresh.
+    let call = 0;
+    const getScreenshot = vi.fn(async () => {
+      call += 1;
+      if (call === 5) return PNG; // success resets the streak
+      throw new Error('target closed');
+    });
+    const loop = new IntentLoop({ session, eventStream: stream as unknown as TemporalEventStream, getScreenshot, classifyByVlm: classify });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      loop.start();
+      for (let i = 0; i < 6; i++) {
+        session.internalEmitter.emit('escalate', {
+          from: 'semantic',
+          regions: [{ nodeId: `n-${i}`, bbox: { x: 0, y: 0, w: 10, h: 10 } }],
+        });
+        await new Promise((r) => setTimeout(r, 0));
+      }
+      const errorScreenshotLogs = logSpy.mock.calls.filter((c) => {
+        const [prefix, msg] = c;
+        return typeof prefix === 'string' && prefix.includes('[ERROR]') &&
+               typeof msg === 'string' && /screenshot/i.test(msg);
+      });
+      // Run 1 (calls 1-4): 3 per-failure ERROR + 1 suppression ERROR = 4.
+      // Run 2 (call 6, after the reset): 1 fresh ERROR. Without the reset,
+      // call 6 would be streak=6 → silent → only 4 total.
+      expect(errorScreenshotLogs.length).toBe(5);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
 });

--- a/packages/core/tests/unit/pipelines/perception/semantic-loop.test.ts
+++ b/packages/core/tests/unit/pipelines/perception/semantic-loop.test.ts
@@ -468,6 +468,66 @@ describe('SemanticLoop', () => {
     expect(intentHandler).not.toHaveBeenCalled();
   });
 
+  it('resets inFlight after a failed tick so the next escalation can re-enter tick() (test gap C)', async () => {
+    const { session, stream } = mkSession();
+    await session.start(0);
+    // extractStructure throws on EVERY call. The finally{ inFlight = false } is
+    // load-bearing: if a refactor moved the reset into the success branch,
+    // inFlight would stay true after the first bad tick and the loop would
+    // deadlock — extractStructure would be called only once. Proving it's
+    // called twice proves the reset survived.
+    const extractStructure = vi.fn(async () => { throw new Error('extract-boom'); });
+    const structural = { extractStructure } as unknown as StructuralPipeline;
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      indexer: mkIndexer(new Map()),
+      structuralPipeline: structural,
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      loop.start();
+      session.internalEmitter.emit('escalate', { from: 'frame', regions: [] });
+      await vi.advanceTimersByTimeAsync(10);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(extractStructure).toHaveBeenCalledTimes(1);
+
+      // Second escalation after the failed tick must re-enter (inFlight reset).
+      session.internalEmitter.emit('escalate', { from: 'frame', regions: [] });
+      await vi.advanceTimersByTimeAsync(10);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(extractStructure).toHaveBeenCalledTimes(2);
+    } finally {
+      logSpy.mockRestore();
+      loop.stop();
+    }
+  });
+
+  it('stop() is a no-op for the wake timer when none is scheduled (G6 null-path)', async () => {
+    const { session, stream } = mkSession();
+    await session.start(0);
+    const loop = new SemanticLoop({
+      session,
+      eventStream: stream as unknown as TemporalEventStream,
+      indexer: mkIndexer(new Map()),
+      structuralPipeline: mkStructural([]),
+      page: mkPage(),
+      config: { cadenceMs: 200 },
+    });
+    loop.start();
+    // No escalation fired → no wake scheduled.
+    expect((loop as any).wakeTimer).toBeNull();
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    expect(() => loop.stop()).not.toThrow();
+    expect(clearSpy).not.toHaveBeenCalled();
+    expect((loop as any).wakeTimer).toBeNull();
+    clearSpy.mockRestore();
+  });
+
   it('stop() unsubscribes — escalations after stop are ignored', async () => {
     const { session, stream } = mkSession();
     await session.start(0);

--- a/packages/core/tests/unit/pipelines/perception/session.test.ts
+++ b/packages/core/tests/unit/pipelines/perception/session.test.ts
@@ -281,6 +281,43 @@ describe('PerceptionSession composed with loops', () => {
     expect((thrown as Error).message).toMatch(/frameLoop teardown failed/);
   });
 
+  it('stop() aggregates multiple teardown failures in order and preserves their causes (P3-I3, test gap B)', async () => {
+    const deps = mkComposedDeps();
+    const session = new PerceptionSession({ eventStream: deps.stream });
+    await session.start(0, {
+      page: deps.page,
+      frameCapture: deps.frameCapture,
+      indexer: deps.indexer,
+      structuralPipeline: deps.structuralPipeline,
+      classifyByVlm: deps.classifyByVlm,
+      getScreenshot: deps.getScreenshot,
+    });
+
+    // Two distinct teardown steps throw — a generic Error and a TypeError, so
+    // we can prove both the type and the per-step identity survive aggregation.
+    const frameErr = new Error('frameLoop boom');
+    const semanticErr = new TypeError('semanticLoop type boom');
+    vi.spyOn((session as any).frameLoop, 'stop').mockImplementation(() => { throw frameErr; });
+    vi.spyOn((session as any).semanticLoop, 'stop').mockImplementation(() => { throw semanticErr; });
+
+    let thrown: unknown = null;
+    try { session.stop(100); } catch (e) { thrown = e; }
+
+    expect(thrown).toBeInstanceOf(Error);
+    const err = thrown as Error;
+    // Grep-friendly step labels remain, in execution order.
+    expect(err.message).toMatch(/frameLoop\.stop:.*semanticLoop\.stop:/s);
+    // P3-I3: the underlying errors are preserved via `cause` (full stacks +
+    // original types), not collapsed to just their `.message` strings.
+    expect(Array.isArray(err.cause)).toBe(true);
+    const causes = err.cause as Array<{ label: string; err: unknown }>;
+    expect(causes.map((c) => c.label)).toEqual(['frameLoop.stop', 'semanticLoop.stop']);
+    expect(causes[0].err).toBe(frameErr);
+    expect(causes[1].err).toBe(semanticErr);
+    // The TypeError type survives — previously lost when only .message was kept.
+    expect(causes[1].err).toBeInstanceOf(TypeError);
+  });
+
   it('stop() cleanly removes page listeners', async () => {
     const deps = mkComposedDeps();
     const session = new PerceptionSession({ eventStream: deps.stream });


### PR DESCRIPTION
## What

The three non-blocking polish items from PR #10's third review pass (`.review/pass3/VERDICT.md`).

- **#12 (P3-I1/I2)** — add `session.recordScreenshotError()` + `screenshotErrors?` on the summary so a perma-broken-screenshot session is distinguishable from an idle one; route the null-screenshot path through the same handler as the throw path so both share the suppression streak.
- **#13 (P3-I3)** — pass `{ cause: errors }` to the aggregated `session.stop()` error so each teardown step's original type + stack survive (the message previously collapsed them to `.message`).
- **#14 (P3-N1)** — classify nav errors by `err.name === 'TargetClosedError'` first, message regex as fallback only (strings drift across Playwright versions/locales).

## Tests

TDD throughout (RED→GREEN). New coverage for the metric, null/throw streak symmetry, streak reset-on-success (gap A), multi-failure aggregation + cause (gap B), `err.name` classification, SemanticLoop inFlight reset (gap C), and stop() null-wake-timer (G6). Full unit suite 507 passing; perception-e2e green in isolation.

Closes #12
Closes #13
Closes #14