### PR TITLE
Phase 2: vision-svc (Qwen analyze track) — CPU implementation (Tasks 2–10)

### DIFF
--- a/docs/superpowers/plans/2026-06-07-personal-gpu-deploy-phase2-vision-svc.md
+++ b/docs/superpowers/plans/2026-06-07-personal-gpu-deploy-phase2-vision-svc.md
@@ -994,7 +994,10 @@ def build_default_app() -> FastAPI:
 
 
 # uvicorn entrypoint: `uvicorn app.main:app`
-app = None  # set lazily to avoid importing torch during unit tests
+# NB (corrected during implementation): do NOT define a module-level `app = None`.
+# PEP 562 module __getattr__ only fires for names NOT found by normal lookup, so a
+# real `app` global shadows this hook and uvicorn would import that value (None)
+# instead of building the app. Leaving `app` undefined makes access lazily build it.
 def __getattr__(name):  # module-level lazy attribute (PEP 562)
     if name == "app":
         return build_default_app()

--- a/packages/contracts/fixtures/v1/analyze.request.invalid-bad-version.json
+++ b/packages/contracts/fixtures/v1/analyze.request.invalid-bad-version.json
@@ -1,0 +1,1 @@
+{ "api_version": "v2", "png_base64": "AAAA", "regions": [] }

--- a/packages/contracts/fixtures/v1/analyze.request.json
+++ b/packages/contracts/fixtures/v1/analyze.request.json
@@ -1,0 +1,1 @@
+{ "api_version": "v1", "png_base64": "iVBORw0KGgo=", "regions": [], "request_id": "req-123" }

--- a/packages/contracts/fixtures/v1/analyze.response.degraded.json
+++ b/packages/contracts/fixtures/v1/analyze.response.degraded.json
@@ -1,0 +1,5 @@
+{
+  "api_version": "v1", "request_id": "req-123", "status": "degraded",
+  "elements": [], "model_id": "Qwen/Qwen2.5-VL-7B-Instruct", "latency_ms": 8000,
+  "reason": "inference_timeout", "retry_after_ms": 1000, "message": "TimeoutError: inference exceeded 8s"
+}

--- a/packages/contracts/fixtures/v1/analyze.response.invalid-missing-reason.json
+++ b/packages/contracts/fixtures/v1/analyze.response.invalid-missing-reason.json
@@ -1,0 +1,1 @@
+{ "api_version": "v1", "request_id": "req-1", "status": "degraded", "elements": [], "model_id": "m", "latency_ms": 5 }

--- a/packages/contracts/fixtures/v1/analyze.response.ok.json
+++ b/packages/contracts/fixtures/v1/analyze.response.ok.json
@@ -1,0 +1,7 @@
+{
+  "api_version": "v1", "request_id": "req-123", "status": "ok",
+  "elements": [
+    { "label": "button", "confidence": 0.94, "bbox": { "x": 12, "y": 40, "w": 88, "h": 32 }, "text": "Submit", "is_interactable": true }
+  ],
+  "model_id": "Qwen/Qwen2.5-VL-7B-Instruct", "latency_ms": 3120
+}

--- a/packages/contracts/fixtures/v1/analyze.response.warming.json
+++ b/packages/contracts/fixtures/v1/analyze.response.warming.json
@@ -1,0 +1,5 @@
+{
+  "api_version": "v1", "request_id": "req-123", "status": "warming",
+  "elements": [], "model_id": "Qwen/Qwen2.5-VL-7B-Instruct", "latency_ms": 2,
+  "reason": "model_loading", "retry_after_ms": 45000
+}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -11,6 +11,7 @@
       "default": "./dist/index.js"
     }
   },
+  "files": ["dist", "fixtures"],
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -15,6 +15,9 @@
     "build": "tsc",
     "test": "vitest run"
   },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
   "devDependencies": {
     "typescript": "^5.4.0",
     "vitest": "^2.0.0"

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -12,10 +12,43 @@ export interface BBox {
   h: number;
 }
 
+export interface VisionElement {
+  label: string;
+  confidence: number;       // 0–1
+  bbox: BBox;
+  text?: string;
+  is_interactable?: boolean;
+  description?: string;
+}
+
+export type VisionStatus = 'ok' | 'warming' | 'degraded';
+export type VisionReason =
+  | 'model_loading'
+  | 'inference_timeout'
+  | 'inference_error'
+  | 'unreachable';
+
 export interface VisionAnalyzeRequest {
-  apiVersion: typeof VISION_API_VERSION;
-  /** PNG screenshot, base64-encoded (lossless — required for vision models). */
-  pngBase64: string;
-  /** Regions of interest to classify; empty means whole-frame. */
+  api_version: typeof VISION_API_VERSION;
+  png_base64: string;
   regions: BBox[];
+  request_id?: string;
+}
+
+export interface VisionAnalyzeResponse {
+  api_version: typeof VISION_API_VERSION;
+  request_id: string;
+  status: VisionStatus;
+  elements: VisionElement[];
+  model_id: string;
+  latency_ms: number;
+  reason?: VisionReason;
+  retry_after_ms?: number;
+  message?: string;
+}
+
+export interface VisionError {
+  api_version: typeof VISION_API_VERSION;
+  request_id: string;
+  error: { code: string; message: string };
 }

--- a/packages/contracts/src/schema.ts
+++ b/packages/contracts/src/schema.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+export const bboxSchema = z.object({
+  x: z.number(), y: z.number(), w: z.number(), h: z.number(),
+});
+
+export const visionElementSchema = z.object({
+  label: z.string(),
+  confidence: z.number().min(0).max(1),
+  bbox: bboxSchema,
+  text: z.string().optional(),
+  is_interactable: z.boolean().optional(),
+  description: z.string().optional(),
+});
+
+export const visionStatusSchema = z.enum(['ok', 'warming', 'degraded']);
+export const visionReasonSchema = z.enum([
+  'model_loading', 'inference_timeout', 'inference_error', 'unreachable',
+]);
+
+export const visionAnalyzeRequestSchema = z.object({
+  api_version: z.literal('v1'),
+  png_base64: z.string(),
+  regions: z.array(bboxSchema),
+  request_id: z.string().optional(),
+});
+
+export const visionAnalyzeResponseSchema = z
+  .object({
+    api_version: z.literal('v1'),
+    request_id: z.string(),
+    status: visionStatusSchema,
+    elements: z.array(visionElementSchema),
+    model_id: z.string(),
+    latency_ms: z.number(),
+    reason: visionReasonSchema.optional(),
+    retry_after_ms: z.number().optional(),
+    message: z.string().optional(),
+  })
+  .refine((r) => r.status === 'ok' || r.reason !== undefined, {
+    message: 'reason is required when status is not ok',
+    path: ['reason'],
+  });
+
+export const visionErrorSchema = z.object({
+  api_version: z.literal('v1'),
+  request_id: z.string(),
+  error: z.object({ code: z.string(), message: z.string() }),
+});

--- a/packages/contracts/tests/contracts.test.ts
+++ b/packages/contracts/tests/contracts.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { VISION_API_VERSION, type VisionAnalyzeRequest } from '../src/index.js';
+import {
+  visionAnalyzeResponseSchema,
+  visionAnalyzeRequestSchema,
+} from '../src/schema.js';
 
 describe('vision contract', () => {
   it('pins the API version', () => {
@@ -7,11 +11,35 @@ describe('vision contract', () => {
   });
 
   it('constructs a valid analyze request', () => {
-    const req: VisionAnalyzeRequest = {
-      apiVersion: 'v1',
-      pngBase64: 'AAAA',
-      regions: [],
-    };
+    const req: VisionAnalyzeRequest = { api_version: 'v1', png_base64: 'AAAA', regions: [] };
     expect(req.regions).toEqual([]);
+  });
+});
+
+describe('vision /v1 zod schemas', () => {
+  it('accepts a well-formed ok response', () => {
+    const ok = {
+      api_version: 'v1',
+      request_id: 'r1',
+      status: 'ok',
+      elements: [{ label: 'button', confidence: 0.9, bbox: { x: 1, y: 2, w: 3, h: 4 } }],
+      model_id: 'qwen2.5-vl-7b',
+      latency_ms: 1200,
+    };
+    expect(() => visionAnalyzeResponseSchema.parse(ok)).not.toThrow();
+  });
+
+  it('rejects a non-ok response with no reason (discriminator invariant)', () => {
+    const bad = {
+      api_version: 'v1', request_id: 'r1', status: 'degraded',
+      elements: [], model_id: 'qwen2.5-vl-7b', latency_ms: 5,
+    };
+    expect(() => visionAnalyzeResponseSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects a request with a bad api_version', () => {
+    expect(() => visionAnalyzeRequestSchema.parse({
+      api_version: 'v2', png_base64: 'AAAA', regions: [],
+    })).toThrow();
   });
 });

--- a/packages/contracts/tests/fixtures.test.ts
+++ b/packages/contracts/tests/fixtures.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  visionAnalyzeRequestSchema,
+  visionAnalyzeResponseSchema,
+} from '../src/schema.js';
+
+const dir = resolve(dirname(fileURLToPath(import.meta.url)), '../fixtures/v1');
+const load = (f: string) => JSON.parse(readFileSync(resolve(dir, f), 'utf-8'));
+
+describe('canonical /v1 fixtures (cross-language source of truth)', () => {
+  it('valid request fixture parses', () => {
+    expect(() => visionAnalyzeRequestSchema.parse(load('analyze.request.json'))).not.toThrow();
+  });
+  it.each(['analyze.response.ok.json', 'analyze.response.warming.json', 'analyze.response.degraded.json'])(
+    'valid response fixture parses: %s',
+    (f) => expect(() => visionAnalyzeResponseSchema.parse(load(f))).not.toThrow(),
+  );
+  it('invalid response fixture is rejected', () => {
+    expect(() => visionAnalyzeResponseSchema.parse(load('analyze.response.invalid-missing-reason.json'))).toThrow();
+  });
+  it('invalid request fixture is rejected', () => {
+    expect(() => visionAnalyzeRequestSchema.parse(load('analyze.request.invalid-bad-version.json'))).toThrow();
+  });
+});

--- a/packages/core/tests/unit/contracts-boundary.test.ts
+++ b/packages/core/tests/unit/contracts-boundary.test.ts
@@ -8,11 +8,11 @@ describe('@uipe/contracts boundary', () => {
 
   it('VisionAnalyzeRequest shape is usable from core', () => {
     const req: VisionAnalyzeRequest = {
-      apiVersion: 'v1',
-      pngBase64: 'iVBORw0KGgo=',
+      api_version: 'v1',
+      png_base64: 'iVBORw0KGgo=',
       regions: [{ x: 0, y: 0, w: 10, h: 10 }],
     };
-    expect(req.apiVersion).toBe('v1');
+    expect(req.api_version).toBe('v1');
     expect(req.regions).toHaveLength(1);
   });
 });

--- a/packages/vision-svc/.dockerignore
+++ b/packages/vision-svc/.dockerignore
@@ -1,0 +1,10 @@
+# The CUDA image only needs requirements.txt + app/ (see Dockerfile).
+# Keep the Fly build context small so deploys upload fast.
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+*.egg-info/
+tests/
+bench/
+.gitignore

--- a/packages/vision-svc/Dockerfile
+++ b/packages/vision-svc/Dockerfile
@@ -1,0 +1,16 @@
+FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3.11 python3-pip git && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /srv
+COPY requirements.txt .
+# CUDA torch wheel + model libs (pinned at build; these are Linux/CUDA, free of the Mac 2.2.2 pin)
+RUN pip3 install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cu124 \
+ && pip3 install --no-cache-dir "transformers>=4.49,<5" accelerate qwen-vl-utils \
+ && pip3 install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+ENV VISION_MODEL_ID=Qwen/Qwen2.5-VL-7B-Instruct
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/packages/vision-svc/app/config.py
+++ b/packages/vision-svc/app/config.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class Config:
+    model_id: str = "Qwen/Qwen2.5-VL-7B-Instruct"
+    inference_timeout_s: float = 8.0
+    warming_retry_after_ms: int = 45000
+    retryable_backoff_ms: int = 1000
+
+    @staticmethod
+    def from_env(env: Mapping[str, str]) -> "Config":
+        return Config(
+            model_id=env.get("VISION_MODEL_ID", Config.model_id),
+            inference_timeout_s=float(env.get("VISION_TIMEOUT_S", Config.inference_timeout_s)),
+            warming_retry_after_ms=int(env.get("VISION_WARMING_RETRY_MS", Config.warming_retry_after_ms)),
+            retryable_backoff_ms=int(env.get("VISION_RETRY_BACKOFF_MS", Config.retryable_backoff_ms)),
+        )

--- a/packages/vision-svc/app/main.py
+++ b/packages/vision-svc/app/main.py
@@ -1,0 +1,77 @@
+import asyncio
+import logging
+import time
+import uuid
+from typing import Protocol
+
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from app.config import Config
+from app.mapping import parse_qwen_output
+from app.schema import VisionAnalyzeRequest, VisionAnalyzeResponse
+
+log = logging.getLogger("vision-svc")
+
+
+class Analyzer(Protocol):
+    model_id: str
+    @property
+    def ready(self) -> bool: ...
+    async def infer(self, png_base64: str, regions: list) -> str: ...
+
+
+def create_app(analyzer: Analyzer, timeout_s: float | None = None) -> FastAPI:
+    cfg = Config.from_env({})
+    timeout = timeout_s if timeout_s is not None else cfg.inference_timeout_s
+    app = FastAPI(title="uipe-vision-svc")
+
+    @app.exception_handler(RequestValidationError)
+    async def _on_validation_error(request: Request, exc: RequestValidationError):
+        rid = (request.headers.get("x-request-id") or str(uuid.uuid4()))
+        return JSONResponse(
+            status_code=422,
+            content={"api_version": "v1", "request_id": rid,
+                     "error": {"code": "invalid_request", "message": str(exc.errors())}},
+        )
+
+    @app.get("/v1/health")
+    async def health():
+        return {"ready": analyzer.ready, "model_id": analyzer.model_id}
+
+    @app.post("/v1/analyze")
+    async def analyze(req: VisionAnalyzeRequest) -> VisionAnalyzeResponse:
+        rid = req.request_id or str(uuid.uuid4())
+
+        if not analyzer.ready:
+            return VisionAnalyzeResponse(
+                request_id=rid, status="warming", elements=[], model_id=analyzer.model_id,
+                latency_ms=0.0, reason="model_loading", retry_after_ms=cfg.warming_retry_after_ms,
+            )
+
+        t0 = time.perf_counter()
+        elapsed = lambda: (time.perf_counter() - t0) * 1000.0
+        try:
+            raw = await asyncio.wait_for(
+                analyzer.infer(req.png_base64, req.regions), timeout=timeout
+            )
+            elements = parse_qwen_output(raw)
+            return VisionAnalyzeResponse(
+                request_id=rid, status="ok", elements=elements,
+                model_id=analyzer.model_id, latency_ms=elapsed(),
+            )
+        except asyncio.TimeoutError:
+            return VisionAnalyzeResponse(
+                request_id=rid, status="degraded", elements=[], model_id=analyzer.model_id,
+                latency_ms=elapsed(), reason="inference_timeout", retry_after_ms=cfg.retryable_backoff_ms,
+                message=f"inference exceeded {timeout}s",
+            )
+        except Exception as e:  # honest catch-all; raw detail to logs, opaque message on the wire
+            log.exception("inference failed", extra={"request_id": rid})
+            return VisionAnalyzeResponse(
+                request_id=rid, status="degraded", elements=[], model_id=analyzer.model_id,
+                latency_ms=elapsed(), reason="inference_error", message=f"{type(e).__name__}: {e}",
+            )
+
+    return app

--- a/packages/vision-svc/app/main.py
+++ b/packages/vision-svc/app/main.py
@@ -75,3 +75,21 @@ def create_app(analyzer: Analyzer, timeout_s: float | None = None) -> FastAPI:
             )
 
     return app
+
+
+def build_default_app() -> FastAPI:
+    from app.qwen import QwenAnalyzer
+    cfg = Config.from_env(__import__("os").environ)
+    return create_app(QwenAnalyzer(cfg))
+
+
+# uvicorn entrypoint: `uvicorn app.main:app`
+# NB: intentionally NO module-level `app = ...` global here. PEP 562 module
+# __getattr__ only fires for names not found by normal lookup; defining `app`
+# would shadow this hook and uvicorn would import that value instead of building
+# the app. Leaving `app` undefined makes access lazily build it (and keeps torch
+# out of the import path during unit tests).
+def __getattr__(name):  # module-level lazy attribute (PEP 562)
+    if name == "app":
+        return build_default_app()
+    raise AttributeError(name)

--- a/packages/vision-svc/app/mapping.py
+++ b/packages/vision-svc/app/mapping.py
@@ -1,0 +1,50 @@
+import json
+import re
+from app.schema import VisionElement, BBox
+
+
+class QwenParseError(ValueError):
+    """Raised when the model output cannot be parsed into a detection array.
+    Surfaced upstream as status=degraded reason=inference_error."""
+
+
+_FENCE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL)
+
+
+def _extract_json_array(text: str) -> str:
+    m = _FENCE.search(text)
+    if m:
+        text = m.group(1)
+    start, end = text.find("["), text.rfind("]")
+    if start == -1 or end == -1 or end < start:
+        raise QwenParseError("no JSON array found in model output")
+    return text[start : end + 1]
+
+
+def _clamp(v: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, v))
+
+
+def parse_qwen_output(text: str) -> list[VisionElement]:
+    raw = _extract_json_array(text)
+    try:
+        items = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise QwenParseError(f"invalid JSON: {e}") from e
+    if not isinstance(items, list):
+        raise QwenParseError("model output is not a JSON array")
+
+    elements: list[VisionElement] = []
+    for it in items:
+        b = it["bbox"]
+        elements.append(
+            VisionElement(
+                label=str(it["label"]),
+                confidence=_clamp(float(it.get("confidence", 0.5)), 0.0, 1.0),
+                bbox=BBox(x=float(b["x"]), y=float(b["y"]), w=float(b["w"]), h=float(b["h"])),
+                text=it.get("text"),
+                is_interactable=it.get("is_interactable"),
+                description=it.get("description"),
+            )
+        )
+    return elements

--- a/packages/vision-svc/app/qwen.py
+++ b/packages/vision-svc/app/qwen.py
@@ -1,0 +1,61 @@
+import asyncio
+import base64
+import io
+import threading
+from PIL import Image
+from app.config import Config
+
+DETECTION_PROMPT = (
+    "Detect the UI elements in this screenshot. Return ONLY a JSON array; each item: "
+    '{"label": one of [button,input,link,image,text,icon,dropdown,checkbox,radio,tab,other], '
+    '"confidence": 0..1, "bbox": {"x","y","w","h"} in pixels, '
+    '"text": visible text or null, "is_interactable": bool}. No prose.'
+)
+
+
+class QwenAnalyzer:
+    """Lazy-loads Qwen2.5-VL on first construction in a background thread so the
+    server can answer /v1/health and return status=warming until ready."""
+
+    def __init__(self, cfg: Config):
+        self.cfg = cfg
+        self.model_id = cfg.model_id
+        self._ready = False
+        self._model = None
+        self._processor = None
+        threading.Thread(target=self._load, daemon=True).start()
+
+    @property
+    def ready(self) -> bool:
+        return self._ready
+
+    def _load(self) -> None:
+        import torch
+        from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
+
+        self._model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+            self.model_id, torch_dtype=torch.bfloat16, device_map="cuda",
+        )  # safetensors by default; if any .bin weights, transformers must use weights_only
+        self._processor = AutoProcessor.from_pretrained(self.model_id)
+        self._ready = True
+
+    async def infer(self, png_base64: str, regions: list) -> str:
+        # Offload the blocking generate() to a thread so the event loop (and the
+        # asyncio.wait_for timeout in the handler) stays responsive.
+        return await asyncio.to_thread(self._infer_sync, png_base64)
+
+    def _infer_sync(self, png_base64: str) -> str:
+        from qwen_vl_utils import process_vision_info
+
+        image = Image.open(io.BytesIO(base64.b64decode(png_base64))).convert("RGB")
+        messages = [{"role": "user", "content": [
+            {"type": "image", "image": image},
+            {"type": "text", "text": DETECTION_PROMPT},
+        ]}]
+        text = self._processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        image_inputs, video_inputs = process_vision_info(messages)
+        inputs = self._processor(text=[text], images=image_inputs, videos=video_inputs,
+                                 padding=True, return_tensors="pt").to("cuda")
+        out = self._model.generate(**inputs, max_new_tokens=1024)
+        trimmed = [o[len(i):] for i, o in zip(inputs.input_ids, out)]
+        return self._processor.batch_decode(trimmed, skip_special_tokens=True)[0]

--- a/packages/vision-svc/app/schema.py
+++ b/packages/vision-svc/app/schema.py
@@ -1,0 +1,52 @@
+from typing import Literal, Optional
+from pydantic import BaseModel, Field, model_validator
+
+VisionStatus = Literal["ok", "warming", "degraded"]
+VisionReason = Literal["model_loading", "inference_timeout", "inference_error", "unreachable"]
+
+
+class BBox(BaseModel):
+    x: float
+    y: float
+    w: float
+    h: float
+
+
+class VisionElement(BaseModel):
+    label: str
+    confidence: float = Field(ge=0.0, le=1.0)
+    bbox: BBox
+    text: Optional[str] = None
+    is_interactable: Optional[bool] = None
+    description: Optional[str] = None
+
+
+class VisionAnalyzeRequest(BaseModel):
+    api_version: Literal["v1"]
+    png_base64: str
+    regions: list[BBox]
+    request_id: Optional[str] = None
+
+
+class VisionAnalyzeResponse(BaseModel):
+    api_version: Literal["v1"] = "v1"
+    request_id: str
+    status: VisionStatus
+    elements: list[VisionElement]
+    model_id: str
+    latency_ms: float
+    reason: Optional[VisionReason] = None
+    retry_after_ms: Optional[int] = None
+    message: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _reason_required_when_not_ok(self):
+        if self.status != "ok" and self.reason is None:
+            raise ValueError("reason is required when status is not ok")
+        return self
+
+
+class VisionError(BaseModel):
+    api_version: Literal["v1"] = "v1"
+    request_id: str
+    error: dict  # {"code": str, "message": str}

--- a/packages/vision-svc/bench/scoring.py
+++ b/packages/vision-svc/bench/scoring.py
@@ -1,0 +1,30 @@
+def iou(a: dict, b: dict) -> float:
+    ax2, ay2 = a["x"] + a["w"], a["y"] + a["h"]
+    bx2, by2 = b["x"] + b["w"], b["y"] + b["h"]
+    ix1, iy1 = max(a["x"], b["x"]), max(a["y"], b["y"])
+    ix2, iy2 = min(ax2, bx2), min(ay2, by2)
+    iw, ih = max(0.0, ix2 - ix1), max(0.0, iy2 - iy1)
+    inter = iw * ih
+    if inter == 0.0:
+        return 0.0
+    union = a["w"] * a["h"] + b["w"] * b["h"] - inter
+    return inter / union
+
+
+def interactable_recall(detected: list, expected: list, iou_threshold: float) -> float:
+    """Fraction of expected interactable elements matched by a detection with the
+    same label and IoU >= threshold. Returns 1.0 when nothing is expected."""
+    wanted = [e for e in expected if e.get("is_interactable")]
+    if not wanted:
+        return 1.0
+    matched = 0
+    used = set()
+    for exp in wanted:
+        for i, det in enumerate(detected):
+            if i in used:
+                continue
+            if det["label"] == exp["label"] and iou(det["bbox"], exp["bbox"]) >= iou_threshold:
+                matched += 1
+                used.add(i)
+                break
+    return matched / len(wanted)

--- a/packages/vision-svc/fly.toml
+++ b/packages/vision-svc/fly.toml
@@ -1,0 +1,15 @@
+app = "uipe-vision-svc-bench"
+primary_region = "ord"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[http_service]
+  internal_port = 8000
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[vm]]
+  size = "a10"
+  memory = "16gb"

--- a/packages/vision-svc/pyproject.toml
+++ b/packages/vision-svc/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "uipe-vision-svc"
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v"
+
+[tool.setuptools.packages.find]
+include = ["app*"]

--- a/packages/vision-svc/requirements-dev.txt
+++ b/packages/vision-svc/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest>=8
+httpx>=0.27        # FastAPI TestClient dependency

--- a/packages/vision-svc/requirements.txt
+++ b/packages/vision-svc/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.115,<1
+uvicorn[standard]>=0.30,<1
+pydantic>=2.7,<3
+pillow>=10.3
+# model deps (installed in the CUDA image; see Dockerfile):
+# torch (CUDA build), transformers>=4.49 (Qwen2.5-VL support), accelerate, qwen-vl-utils

--- a/packages/vision-svc/tests/fixtures/qwen_raw/fenced.txt
+++ b/packages/vision-svc/tests/fixtures/qwen_raw/fenced.txt
@@ -1,0 +1,4 @@
+Here are the detected elements:
+```json
+[{"label": "link", "confidence": 0.71, "bbox": {"x": 5, "y": 5, "w": 50, "h": 18}}]
+```

--- a/packages/vision-svc/tests/fixtures/qwen_raw/good.txt
+++ b/packages/vision-svc/tests/fixtures/qwen_raw/good.txt
@@ -1,0 +1,1 @@
+[{"label": "button", "confidence": 0.94, "bbox": {"x": 12, "y": 40, "w": 88, "h": 32}, "text": "Submit", "is_interactable": true}, {"label": "input", "confidence": 0.8, "bbox": {"x": 0, "y": 0, "w": 200, "h": 30}}]

--- a/packages/vision-svc/tests/fixtures/qwen_raw/malformed.txt
+++ b/packages/vision-svc/tests/fixtures/qwen_raw/malformed.txt
@@ -1,0 +1,1 @@
+I could not find any clearly interactable elements in this region.

--- a/packages/vision-svc/tests/test_analyze_handler.py
+++ b/packages/vision-svc/tests/test_analyze_handler.py
@@ -1,0 +1,65 @@
+import asyncio
+import pytest
+from fastapi.testclient import TestClient
+from app.main import create_app, Analyzer
+
+class FakeAnalyzer(Analyzer):
+    def __init__(self, ready=True, model_id="fake-model", behavior="ok"):
+        self._ready = ready
+        self.model_id = model_id
+        self.behavior = behavior  # "ok" | "timeout" | "error"
+    @property
+    def ready(self): return self._ready
+    async def infer(self, png_base64, regions):
+        if self.behavior == "timeout":
+            await asyncio.sleep(10)  # exceeds the test timeout
+        if self.behavior == "error":
+            raise RuntimeError("boom")
+        return '[{"label":"button","confidence":0.9,"bbox":{"x":1,"y":2,"w":3,"h":4}}]'
+
+def _client(analyzer, timeout_s=0.05):
+    return TestClient(create_app(analyzer, timeout_s=timeout_s))
+
+REQ = {"api_version": "v1", "png_base64": "AAAA", "regions": []}
+
+def test_ok_path():
+    r = _client(FakeAnalyzer()).post("/v1/analyze", json=REQ)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["elements"][0]["label"] == "button"
+    assert body["request_id"]  # generated when absent
+
+def test_warming_when_model_not_ready():
+    r = _client(FakeAnalyzer(ready=False)).post("/v1/analyze", json=REQ)
+    body = r.json()
+    assert body["status"] == "warming"
+    assert body["reason"] == "model_loading"
+    assert body["elements"] == []
+    assert body["retry_after_ms"] > 0
+
+def test_degraded_on_timeout():
+    r = _client(FakeAnalyzer(behavior="timeout"), timeout_s=0.05).post("/v1/analyze", json=REQ)
+    body = r.json()
+    assert body["status"] == "degraded"
+    assert body["reason"] == "inference_timeout"
+
+def test_degraded_on_inference_error_carries_opaque_message():
+    r = _client(FakeAnalyzer(behavior="error")).post("/v1/analyze", json=REQ)
+    body = r.json()
+    assert body["status"] == "degraded"
+    assert body["reason"] == "inference_error"
+    assert "RuntimeError" in body["message"]
+
+def test_echoes_caller_request_id():
+    r = _client(FakeAnalyzer()).post("/v1/analyze", json={**REQ, "request_id": "caller-xyz"})
+    assert r.json()["request_id"] == "caller-xyz"
+
+def test_health_reports_readiness():
+    assert _client(FakeAnalyzer(ready=True)).get("/v1/health").json()["ready"] is True
+    assert _client(FakeAnalyzer(ready=False)).get("/v1/health").json()["ready"] is False
+
+def test_malformed_request_returns_4xx_vision_error():
+    r = _client(FakeAnalyzer()).post("/v1/analyze", json={"api_version": "v2", "png_base64": "x", "regions": []})
+    assert r.status_code == 422
+    assert r.json()["error"]["code"] == "invalid_request"

--- a/packages/vision-svc/tests/test_config.py
+++ b/packages/vision-svc/tests/test_config.py
@@ -1,0 +1,12 @@
+from app.config import Config
+
+def test_defaults():
+    cfg = Config.from_env({})
+    assert cfg.model_id == "Qwen/Qwen2.5-VL-7B-Instruct"
+    assert cfg.inference_timeout_s == 8.0
+    assert cfg.warming_retry_after_ms == 45000
+
+def test_env_override():
+    cfg = Config.from_env({"VISION_MODEL_ID": "custom/model", "VISION_TIMEOUT_S": "12"})
+    assert cfg.model_id == "custom/model"
+    assert cfg.inference_timeout_s == 12.0

--- a/packages/vision-svc/tests/test_entrypoint.py
+++ b/packages/vision-svc/tests/test_entrypoint.py
@@ -1,0 +1,16 @@
+import sys
+import app.main as main_mod
+
+
+def test_app_attribute_is_lazy(monkeypatch):
+    # PEP 562: accessing the module-level `app` must invoke build_default_app
+    # lazily (it must NOT be shadowed by a real `app` global). Monkeypatch the
+    # builder so we don't construct the real (torch-requiring) analyzer.
+    monkeypatch.setattr(main_mod, "build_default_app", lambda: "SENTINEL_APP")
+    assert main_mod.app == "SENTINEL_APP"
+
+
+def test_importing_main_does_not_import_torch():
+    # Importing the app module (as the unit tests do) must not pull in torch;
+    # the model libs load only when the real analyzer is built on the GPU.
+    assert "torch" not in sys.modules

--- a/packages/vision-svc/tests/test_mapping.py
+++ b/packages/vision-svc/tests/test_mapping.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import pytest
+from app.mapping import parse_qwen_output, QwenParseError
+
+RAW = Path(__file__).resolve().parent / "fixtures" / "qwen_raw"
+
+def test_parses_bare_json_array():
+    els = parse_qwen_output((RAW / "good.txt").read_text())
+    assert len(els) == 2
+    assert els[0].label == "button"
+    assert els[0].is_interactable is True
+    assert els[1].bbox.w == 200
+
+def test_parses_fenced_json_with_prose():
+    els = parse_qwen_output((RAW / "fenced.txt").read_text())
+    assert len(els) == 1
+    assert els[0].label == "link"
+
+def test_malformed_output_raises():
+    with pytest.raises(QwenParseError):
+        parse_qwen_output((RAW / "malformed.txt").read_text())
+
+def test_confidence_clamped_to_unit_range():
+    els = parse_qwen_output('[{"label":"x","confidence":1.5,"bbox":{"x":0,"y":0,"w":1,"h":1}}]')
+    assert els[0].confidence == 1.0

--- a/packages/vision-svc/tests/test_schema_fixtures.py
+++ b/packages/vision-svc/tests/test_schema_fixtures.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+import pytest
+from pydantic import ValidationError
+from app.schema import VisionAnalyzeRequest, VisionAnalyzeResponse
+
+FIX = Path(__file__).resolve().parents[2] / "contracts" / "fixtures" / "v1"
+
+def _load(name): return json.loads((FIX / name).read_text())
+
+def test_valid_request_fixture():
+    VisionAnalyzeRequest.model_validate(_load("analyze.request.json"))
+
+@pytest.mark.parametrize("name", [
+    "analyze.response.ok.json",
+    "analyze.response.warming.json",
+    "analyze.response.degraded.json",
+])
+def test_valid_response_fixtures(name):
+    VisionAnalyzeResponse.model_validate(_load(name))
+
+def test_invalid_response_missing_reason_rejected():
+    with pytest.raises(ValidationError):
+        VisionAnalyzeResponse.model_validate(_load("analyze.response.invalid-missing-reason.json"))
+
+def test_invalid_request_bad_version_rejected():
+    with pytest.raises(ValidationError):
+        VisionAnalyzeRequest.model_validate(_load("analyze.request.invalid-bad-version.json"))

--- a/packages/vision-svc/tests/test_scoring.py
+++ b/packages/vision-svc/tests/test_scoring.py
@@ -1,0 +1,27 @@
+from bench.scoring import iou, interactable_recall
+
+def test_iou_identical_boxes_is_one():
+    b = {"x": 0, "y": 0, "w": 10, "h": 10}
+    assert iou(b, b) == 1.0
+
+def test_iou_disjoint_boxes_is_zero():
+    assert iou({"x": 0, "y": 0, "w": 10, "h": 10}, {"x": 100, "y": 100, "w": 10, "h": 10}) == 0.0
+
+def test_iou_half_overlap():
+    a = {"x": 0, "y": 0, "w": 10, "h": 10}
+    b = {"x": 5, "y": 0, "w": 10, "h": 10}
+    assert abs(iou(a, b) - (50 / 150)) < 1e-6  # inter=50, union=150
+
+def test_interactable_recall_matches_by_label_and_iou():
+    expected = [
+        {"label": "button", "is_interactable": True, "bbox": {"x": 0, "y": 0, "w": 10, "h": 10}},
+        {"label": "input", "is_interactable": True, "bbox": {"x": 50, "y": 0, "w": 20, "h": 10}},
+    ]
+    detected = [
+        {"label": "button", "bbox": {"x": 1, "y": 1, "w": 10, "h": 10}},   # matches button (IoU>0.5)
+        {"label": "link", "bbox": {"x": 50, "y": 0, "w": 20, "h": 10}},    # wrong label for the input
+    ]
+    assert interactable_recall(detected, expected, iou_threshold=0.5) == 0.5
+
+def test_interactable_recall_no_expected_is_one():
+    assert interactable_recall([], [], iou_threshold=0.5) == 1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,10 @@ importers:
   .: {}
 
   packages/contracts:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       typescript:
         specifier: ^5.4.0


### PR DESCRIPTION
## Phase 2 — vision-svc (Qwen2.5-VL analyze track): CPU implementation

Implements **Tasks 2–10** of the Phase 2 plan (`docs/superpowers/plans/2026-06-07-personal-gpu-deploy-phase2-vision-svc.md`) — the entire CPU-testable vertical slice for the Qwen "analyze" track. Built task-by-task with TDD; each task has its own commit.

### What's in
- **`@uipe/contracts` `/v1` wire contract** finalized to **snake_case** + zod schemas, incl. the discriminator invariant *(reason required when status ≠ ok)*. Seed boundary test migrated; `core` consumer test migrated.
- **Canonical cross-language JSON fixtures** (`packages/contracts/fixtures/v1/*.json`) validated by **both** zod (TS) and Pydantic (Python) — a real shared source of truth, not parallel copies.
- **`packages/vision-svc/`** (new Python package): `config`, Pydantic `schema`, tolerant Qwen-output `mapping`, FastAPI `/v1/analyze` + `/v1/health` with the **status/reason classification ladder** (classification by control-flow + exception type, never by parsing error strings), the lazy GPU `QwenAnalyzer`, the CUDA `Dockerfile` + ephemeral A10 `fly.toml`, and pure-function bench scoring (IoU + interactable recall).

### Out of scope (owner-driven, cost money — NOT in this PR)
- **Task 1** Fly A10 capacity/region gate
- **Task 11** golden set + `run_bench.py`
- **Task 12** ephemeral A10 deploy → Unit-0-lite bench → `SCORECARD.md` → teardown

### Verification (CPU Definition-of-Done — all green)
- `pnpm -F @uipe/contracts exec vitest run` → **11 passed**
- `pnpm -r exec -- tsc --noEmit` → **exit 0** (after a contracts rebuild — `core` consumes contracts via built `dist/`)
- `cd packages/vision-svc && .venv/bin/python -m pytest` → **26 passed** (config, schema-fixtures, mapping, handler, entrypoint, scoring)
- TS↔Python schemas validate/reject the same canonical fixtures.

> Local note: the Mac default python is 3.9; vision-svc CPU tests run in a `python3.11` venv at `packages/vision-svc/.venv` (gitignored).

### Notable deviations from the plan (intentional)
- **PEP 562 entrypoint bug fixed.** The plan appended both `app = None` and a module `__getattr__` to `app/main.py`; the global shadows the hook, so `uvicorn app.main:app` would serve `None` (verified empirically). Dropped `app = None`, added regression test `tests/test_entrypoint.py`, and corrected the plan doc.
- **Added `packages/vision-svc/.dockerignore`** so the Fly build context doesn't ship the multi-GB `.venv`.

### Deferred follow-up (decided)
- On-wire `message` currently carries `type(e).__name__: {e}` (per the plan; fine for single-tenant Phase 2). **Phase 4 (hosted/multi-tenant egress):** scrub it to a fixed opaque string, keep full detail in logs, strengthen the test. Tracked in VFS `decisions/phase2-onwire-error-message-scrub-deferred.md`.
