### PR TITLE
docs(phase2): substrate-pivot amendment — Fly is dead

### DIFF
--- a/docs/superpowers/plans/2026-06-07-personal-gpu-deploy-phase2-vision-svc.md
+++ b/docs/superpowers/plans/2026-06-07-personal-gpu-deploy-phase2-vision-svc.md
@@ -43,44 +43,9 @@ Each file has one responsibility: `schema.py` = wire DTOs; `mapping.py` = Qwen-t
 
 ## Task 1: ~~Fly A10 capacity/region gate~~ ⚠️ SUPERSEDED → Task 1′ (substrate bring-up)
 
-> **Fly is dead.** This task is replaced by **Task 1′** in the [substrate-pivot amendment](../specs/2026-06-08-phase2-substrate-pivot-amendment.md) §4 — substrate-agnostic bring-up (hosted API / Modal / 3090). The `fly auth`/`fly machine run`/`fly apps destroy` steps below no longer apply (Modal/hosted have no capacity gate). Original text kept as the decision trail.
-
-This is the spec's gating prerequisite. Not TDD — an ops check that must pass before sinking effort into the model code. Do this first; if it fails, stop and escalate.
-
-**Files:** none (records findings in the commit message / `packages/vision-svc/README.md` later).
-
-- [ ] **Step 1: Confirm Fly CLI auth**
-
-Run: `fly auth whoami`
-Expected: prints your Fly account email. If not, `fly auth login`.
-
-- [ ] **Step 2: List GPU sizes and regions**
-
-Run: `fly platform vm-sizes | grep -i a10` and `fly platform regions`
-Expected: an `a10` GPU size is listed. Note 1-2 regions you want (e.g. `ord`, `iad`).
-
-- [ ] **Step 3: Smoke-allocate a throwaway A10 machine**
-
-```bash
-fly apps create uipe-a10-capacity-check --machines
-fly machine run nvidia/cuda:12.4.1-runtime-ubuntu22.04 \
-  --app uipe-a10-capacity-check --vm-gpu-kind a10 --region ord \
-  --command "nvidia-smi" --rm
-```
-Expected: the machine boots and `nvidia-smi` prints an A10 GPU table. A capacity/region error here is the signal to escalate (try another region, or revisit the substrate assumption) **before** proceeding.
-
-- [ ] **Step 4: Tear down the check app**
-
-```bash
-fly apps destroy uipe-a10-capacity-check --yes
-```
-Expected: app destroyed. Record the working region for Task 12.
-
-- [ ] **Step 5: Commit a note** (no code yet — record the gate result)
-
-```bash
-git commit --allow-empty -m "chore(phase2): confirm Fly A10 capacity in <region>"
-```
+> **⚠️ SUPERSEDED — Fly is dead.** Replaced by **Task 1′** (substrate-agnostic bring-up: hosted API / Modal / 3090) in the [substrate-pivot amendment](../specs/2026-06-08-phase2-substrate-pivot-amendment.md) §4.
+>
+> The original Fly capacity-gate commands (`fly auth` / `fly platform` / `fly machine run` / `fly apps destroy`) were **excised here to avoid an agent running dead infra** from a retrieved chunk. They remain verbatim in git history at commit `2da9816` (PR #21) if needed for audit.
 
 ---
 
@@ -1035,12 +1000,12 @@ git commit -m "feat(vision-svc): Qwen2.5-VL analyzer (lazy GPU load, threaded in
 > [amendment](../specs/2026-06-08-phase2-substrate-pivot-amendment.md) §4 Task 9′.
 
 **Files:**
-- Create: `packages/vision-svc/Dockerfile`
-- Create: `packages/vision-svc/fly.toml`
+- Create: `packages/vision-svc/Dockerfile` (live — portable CUDA reference image)
+- ~~Create: `packages/vision-svc/fly.toml`~~ **dead** — per-substrate config (Modal ASGI / systemd / env-only) is in [amendment](../specs/2026-06-08-phase2-substrate-pivot-amendment.md) §4 Task 9′.
 
-> Validated by the ephemeral deploy in Task 12, not by a unit test. Verify the CUDA base tag and the Fly GPU stanza against current Fly docs at deploy time.
+> Validated by the deploy in Task 12′, not by a unit test. Verify the CUDA base tag against current docs at deploy time.
 
-- [ ] **Step 1: Write the Dockerfile**
+- [ ] **Step 1: Write the Dockerfile** (still live — runs on Modal/3090 unchanged)
 
 ```dockerfile
 FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04
@@ -1061,37 +1026,7 @@ EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
 ```
 
-- [ ] **Step 2: Write the ephemeral `fly.toml`** (GPU, auto-stop, scale-to-zero)
-
-```toml
-app = "uipe-vision-svc-bench"
-primary_region = "ord"
-
-[build]
-  dockerfile = "Dockerfile"
-
-[http_service]
-  internal_port = 8000
-  auto_stop_machines = true
-  auto_start_machines = true
-  min_machines_running = 0
-
-[[vm]]
-  size = "a10"
-  memory = "16gb"
-```
-
-- [ ] **Step 3: Local Docker build sanity check** (no GPU needed to validate the build graph; skip the run)
-
-Run: `cd packages/vision-svc && docker build -t uipe-vision-svc:local . 2>&1 | tail -5` (optional — skip if Docker/disk is constrained on the Mac; the real build happens on Fly)
-Expected: build completes, or is deferred to the Fly build in Task 12.
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add packages/vision-svc/Dockerfile packages/vision-svc/fly.toml
-git commit -m "feat(vision-svc): CUDA Dockerfile + ephemeral Fly A10 config"
-```
+> **⚠️ The original `fly.toml` (GPU/auto-stop/`size = "a10"`) + the Fly build/commit steps were excised here** (dead infra; would mislead a retrieved chunk). Verbatim in git history at commit `2da9816` (PR #21). The Dockerfile above stays; its substrate config is Task 9′.
 
 ---
 
@@ -1297,15 +1232,14 @@ Qwen2.5-VL analyze service for the personal GPU deploy (Phase 2).
 ## Local (CPU) tests
 `python -m pytest`  — contract/schema/mapping/handler/scoring. No GPU, no model.
 
-## ~~Ephemeral A10 benchmark~~ Benchmark (Unit-0-lite) — ⚠️ substrate AMENDED
-> Fly steps below are dead. The benchmark itself is substrate-agnostic — `run_bench.py`
-> takes `--base-url`, so point it at a Modal URL, the hosted-API service, or `localhost`.
-> Bring-up + teardown per substrate: [amendment](../specs/2026-06-08-phase2-substrate-pivot-amendment.md) §4 (Modal/hosted scale to zero — no `fly apps destroy`).
-1. ~~`fly deploy --config fly.toml`~~ Bring up the chosen substrate (Task 1′).
+## Benchmark (Unit-0-lite) — substrate-agnostic
+> Run against whichever substrate is chosen (amendment §3): a Modal URL, the hosted-API
+> service, or `localhost`. `run_bench.py` takes `--base-url`, so nothing here is substrate-specific.
+1. Bring up the chosen substrate (amendment Task 1′).
 2. `python bench/run_bench.py --base-url <substrate-url-or-localhost>`
    (first calls return status=warming while the model loads; the runner retries).
 3. Read the scorecard; PASS = mean interactable recall >= 0.80 and p95 latency <= 8000ms.
-4. ~~`fly apps destroy …`~~ Teardown is substrate-specific (scale-to-zero = nothing to do).
+4. Teardown is substrate-specific (Modal/hosted scale to zero — nothing to do; a 3090 just idles).
 
 If Qwen FAILS the bar, add InternVL2.5 / Florence-2 (swap VISION_MODEL_ID), re-run,
 pick the best — or ship vision-degraded (structural-only) per the spec escape hatch.
@@ -1327,57 +1261,9 @@ git commit -m "feat(vision-svc): golden set + run_bench.py eval runner + runbook
 
 ## Task 12: ~~Ephemeral [Fly] deploy~~ → bench → golden eval → (teardown) — ⚠️ SUPERSEDED → Task 12′
 
-> **Fly is dead.** Replaced by **Task 12′** in the [amendment](../specs/2026-06-08-phase2-substrate-pivot-amendment.md) §4 — same shape (deploy → bench → score → record) on the chosen substrate, minus Fly spin-up/`fly apps destroy` (scale-to-zero). Blocked on the §3 substrate decision + the golden set TODO. Original Fly steps kept as the decision trail.
-
-Not TDD — the real-GPU validation. This is where Qwen is confirmed (or challenged) on actual screenshots.
-
-**Files:** updates `packages/vision-svc/bench/SCORECARD.md` with the recorded result.
-
-- [ ] **Step 1: Deploy to the ephemeral A10**
-
-```bash
-cd packages/vision-svc
-fly launch --no-deploy --copy-config --name uipe-vision-svc-bench   # if app not yet created
-fly deploy --config fly.toml
-```
-Expected: image builds, an A10 machine boots, `fly status` shows it running. Model load happens on first request (warming).
-
-- [ ] **Step 2: Health check**
-
-Run: `curl https://uipe-vision-svc-bench.fly.dev/v1/health`
-Expected: `{"ready": false, ...}` initially, then `{"ready": true, ...}` after the model finishes loading (~30–60s).
-
-- [ ] **Step 3: Run the benchmark**
-
-Run: `python bench/run_bench.py --base-url https://uipe-vision-svc-bench.fly.dev`
-Expected: a scorecard table + `RESULT: PASS` or `FAIL`.
-
-- [ ] **Step 4: Record the decision**
-
-Write `bench/SCORECARD.md` with the date, model_id, the table, mean recall, p95 latency, and the decision (Qwen confirmed / challenger needed / vision-degraded). This is the Unit-0-lite output the spec calls for.
-
-- [ ] **Step 5: If FAIL — challenge** (only if needed)
-
-```bash
-fly secrets set VISION_MODEL_ID=OpenGVLab/InternVL2_5-8B --app uipe-vision-svc-bench
-fly deploy --config fly.toml
-python bench/run_bench.py --base-url https://uipe-vision-svc-bench.fly.dev
-```
-Repeat with Florence-2 if needed; pick the best, or invoke the vision-degraded escape hatch and document it. Update `SCORECARD.md`.
-
-- [ ] **Step 6: Tear down (stop billing)**
-
-```bash
-fly apps destroy uipe-vision-svc-bench --yes
-```
-Expected: app destroyed.
-
-- [ ] **Step 7: Commit the scorecard**
-
-```bash
-git add packages/vision-svc/bench/SCORECARD.md
-git commit -m "docs(vision-svc): Unit-0-lite scorecard + model decision"
-```
+> **⚠️ SUPERSEDED — Fly is dead.** Replaced by **Task 12′** in the [substrate-pivot amendment](../specs/2026-06-08-phase2-substrate-pivot-amendment.md) §4 — same shape (deploy → bench → score → record `bench/SCORECARD.md`) on the chosen substrate, minus Fly spin-up/`fly apps destroy` (scale-to-zero). Blocked on the §3 substrate decision + the golden-set TODO.
+>
+> The original Fly deploy/health/challenge/teardown commands (`fly launch` / `fly deploy` / `fly secrets set` / `fly apps destroy`) were **excised here to avoid an agent running dead infra** from a retrieved chunk. They remain verbatim in git history at commit `2da9816` (PR #21) for audit. The model-decision logic (Qwen confirmed / challenger / vision-degraded) is unchanged and lives in Task 12′.
 
 ---
 

--- a/docs/superpowers/plans/2026-06-07-personal-gpu-deploy-phase2-vision-svc.md
+++ b/docs/superpowers/plans/2026-06-07-personal-gpu-deploy-phase2-vision-svc.md
@@ -9,11 +9,11 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Build and validate the Qwen2.5-VL "analyze" vertical slice — a Python `vision-svc` serving `/v1/analyze`, the pinned `@uipe/contracts` `/v1` schema it speaks, and a real-GPU benchmark/eval on an ephemeral Fly A10 that confirms Qwen on real UIPE screenshots.
+**Goal:** Build and validate the Qwen2.5-VL "analyze" vertical slice — a Python `vision-svc` serving `/v1/analyze`, the pinned `@uipe/contracts` `/v1` schema it speaks, and a real-GPU benchmark/eval on the chosen substrate (see the [substrate-pivot amendment](../specs/2026-06-08-phase2-substrate-pivot-amendment.md)) that confirms Qwen on real UIPE screenshots.
 
-**Architecture:** A new Python FastAPI service (`packages/vision-svc/`) loads Qwen2.5-VL-7B and exposes `POST /v1/analyze` + `GET /v1/health`. The wire contract lives in `@uipe/contracts` and is enforced cross-language by shared JSON fixtures (TS+zod consumer side, Pydantic producer side). Failures are classified by control-flow position and exception type into a small `status`/`reason` enum — never by parsing error strings. The model runs only on an ephemeral A10 spun up for the bench/eval and torn down after.
+**Architecture:** A new Python FastAPI service (`packages/vision-svc/`) loads Qwen2.5-VL-7B and exposes `POST /v1/analyze` + `GET /v1/health`. The wire contract lives in `@uipe/contracts` and is enforced cross-language by shared JSON fixtures (TS+zod consumer side, Pydantic producer side). Failures are classified by control-flow position and exception type into a small `status`/`reason` enum — never by parsing error strings. The model runs on the chosen GPU substrate (hosted API / Modal / 3090 — see the [substrate-pivot amendment](../specs/2026-06-08-phase2-substrate-pivot-amendment.md)); the contract + mapping tests need no GPU.
 
-**Tech Stack:** TypeScript + zod + vitest (contracts); Python 3.11 + FastAPI + Pydantic v2 + pytest (vision-svc); transformers + torch (CUDA) for Qwen2.5-VL; Fly.io A10 GPU; Docker (CUDA base).
+**Tech Stack:** TypeScript + zod + vitest (contracts); Python 3.11 + FastAPI + Pydantic v2 + pytest (vision-svc); transformers + torch (CUDA) for Qwen2.5-VL; a 24 GB CUDA GPU substrate (Modal / used 3090) or a hosted VLM API — see the amendment; Docker (CUDA base).
 
 **Spec:** [`docs/superpowers/specs/2026-06-07-personal-gpu-deploy-phase2-vision-svc-design.md`](../specs/2026-06-07-personal-gpu-deploy-phase2-vision-svc-design.md)
 
@@ -35,7 +35,7 @@
 - `app/__init__.py`, `app/config.py`, `app/schema.py`, `app/mapping.py`, `app/qwen.py`, `app/main.py`
 - `bench/scoring.py`, `bench/run_bench.py`, `bench/golden/` (screenshots + `expected/*.json`)
 - `tests/test_schema_fixtures.py`, `tests/test_mapping.py`, `tests/test_analyze_handler.py`, `tests/test_scoring.py`, `tests/fixtures/qwen_raw/*.txt`
-- `Dockerfile`, `fly.toml`
+- `Dockerfile` (portable CUDA reference image; per-substrate config lives in the [amendment](../specs/2026-06-08-phase2-substrate-pivot-amendment.md) §4, not `fly.toml`)
 
 Each file has one responsibility: `schema.py` = wire DTOs; `mapping.py` = Qwen-text → DTO (the only model-format-aware code); `qwen.py` = model load+infer; `main.py` = transport + the classification ladder; `bench/scoring.py` = pure metrics; `bench/run_bench.py` = the eval runner.
 
@@ -889,7 +889,7 @@ git commit -m "feat(vision-svc): /v1/analyze handler with status/reason classifi
 **Files:**
 - Create: `packages/vision-svc/app/qwen.py`
 
-> This code runs ONLY on the A10 — it cannot be unit-tested on the Mac. It is validated by the golden eval (Task 12). Before relying on the exact transformers API below, verify it against the current Qwen2.5-VL model card (transformers ≥4.49 introduced `Qwen2_5_VLForConditionalGeneration`); the processor/`generate` surface shifts between releases. (Offer: a context7 lookup of "Qwen2.5-VL transformers usage" at implementation time.)
+> This code runs ONLY on a CUDA GPU substrate (Modal / 3090) — it cannot be unit-tested on the Mac. It is validated by the golden eval (Task 12′). Before relying on the exact transformers API below, verify it against the current Qwen2.5-VL model card (transformers ≥4.49 introduced `Qwen2_5_VLForConditionalGeneration`); the processor/`generate` surface shifts between releases. (Offer: a context7 lookup of "Qwen2.5-VL transformers usage" at implementation time.)
 
 - [ ] **Step 1: Write `app/qwen.py`**
 
@@ -1154,10 +1154,11 @@ For each screenshot, hand-write `expected/<name>.json` — the elements you'd ex
 
 ```python
 """Unit-0-lite: POST each golden screenshot to a running /v1/analyze, score the
-result against the hand-labeled expectations, print a scorecard. Run against an
-ephemeral Fly A10 deploy (Task 12) — dogfoods the real contract + serve path.
+result against the hand-labeled expectations, print a scorecard. Run against the
+chosen GPU substrate (Modal / 3090) or a hosted VLM API — dogfoods the real
+contract + serve path. See docs substrate-pivot amendment, Task 12'.
 
-Usage: python bench/run_bench.py --base-url https://<app>.fly.dev
+Usage: python bench/run_bench.py --base-url <substrate-url-or-localhost>
 """
 import argparse
 import base64
@@ -1272,5 +1273,5 @@ git commit -m "feat(vision-svc): golden set + run_bench.py eval runner + runbook
 - `pnpm -F @uipe/contracts exec vitest run` green; `pnpm -r exec -- tsc --noEmit` clean.
 - `cd packages/vision-svc && python -m pytest` green (config, schema-fixtures, mapping, handler, scoring) — all CPU, no model.
 - The same canonical fixtures validate on both the TS (zod) and Python (Pydantic) sides.
-- An ephemeral A10 deploy serves `/v1/analyze`; `run_bench.py` produces a scorecard; the model decision is recorded in `SCORECARD.md`; the ephemeral app is destroyed.
-- No persistent Fly deploy, no session-host wiring, no `/v1/flow`, no OmniParser removal (those are Phases 3–4 and the optical-flow phase).
+- A deploy on the chosen substrate (amendment Task 12′) serves `/v1/analyze`; `run_bench.py` produces a scorecard; the model decision is recorded in `SCORECARD.md`.
+- No persistent deploy, no session-host wiring, no `/v1/flow`, no OmniParser removal (those are Phases 3–4 and the optical-flow phase).

--- a/docs/superpowers/plans/2026-06-07-personal-gpu-deploy-phase2-vision-svc.md
+++ b/docs/superpowers/plans/2026-06-07-personal-gpu-deploy-phase2-vision-svc.md
@@ -1,5 +1,12 @@
 # Phase 2 — vision-svc (Qwen analyze track) Implementation Plan
 
+> **⚠️ STATUS 2026-06-08: Tasks 2–10 SHIPPED (PR #22/#23). Tasks 1 / 9 / 12 SUPERSEDED — Fly is dead.**
+> See [`../specs/2026-06-08-phase2-substrate-pivot-amendment.md`](../specs/2026-06-08-phase2-substrate-pivot-amendment.md).
+> The contract/CPU work (Tasks 2–10) is merged and unaffected. The three **ops** tasks
+> were Fly-specific and are replaced by the amendment's substrate-agnostic **Task 1′ / 9′ /
+> 12′** (substrate PENDING: hosted API / Modal / used-3090 rig). Ignore "Fly", "A10",
+> "ephemeral deploy", and "`fly apps destroy`" below — read those tasks via the amendment.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Build and validate the Qwen2.5-VL "analyze" vertical slice — a Python `vision-svc` serving `/v1/analyze`, the pinned `@uipe/contracts` `/v1` schema it speaks, and a real-GPU benchmark/eval on an ephemeral Fly A10 that confirms Qwen on real UIPE screenshots.
@@ -34,7 +41,9 @@ Each file has one responsibility: `schema.py` = wire DTOs; `mapping.py` = Qwen-t
 
 ---
 
-## Task 1: Fly A10 capacity/region gate (ops — verify early)
+## Task 1: ~~Fly A10 capacity/region gate~~ ⚠️ SUPERSEDED → Task 1′ (substrate bring-up)
+
+> **Fly is dead.** This task is replaced by **Task 1′** in the [substrate-pivot amendment](../specs/2026-06-08-phase2-substrate-pivot-amendment.md) §4 — substrate-agnostic bring-up (hosted API / Modal / 3090). The `fly auth`/`fly machine run`/`fly apps destroy` steps below no longer apply (Modal/hosted have no capacity gate). Original text kept as the decision trail.
 
 This is the spec's gating prerequisite. Not TDD — an ops check that must pass before sinking effort into the model code. Do this first; if it fails, stop and escalate.
 
@@ -1018,7 +1027,12 @@ git commit -m "feat(vision-svc): Qwen2.5-VL analyzer (lazy GPU load, threaded in
 
 ---
 
-## Task 9: Dockerfile (CUDA) + Fly config
+## Task 9: Dockerfile (CUDA) ~~+ Fly config~~ ⚠️ AMENDED → Task 9′
+
+> **Dockerfile STAYS** as the portable CUDA reference image (runs on Modal/3090 unchanged).
+> **`fly.toml` is DEAD** — leave as a historical artifact or delete (254 B). Per-substrate
+> config (Modal ASGI wrapper / systemd unit / env-only for hosted) is in the
+> [amendment](../specs/2026-06-08-phase2-substrate-pivot-amendment.md) §4 Task 9′.
 
 **Files:**
 - Create: `packages/vision-svc/Dockerfile`
@@ -1283,12 +1297,15 @@ Qwen2.5-VL analyze service for the personal GPU deploy (Phase 2).
 ## Local (CPU) tests
 `python -m pytest`  — contract/schema/mapping/handler/scoring. No GPU, no model.
 
-## Ephemeral A10 benchmark (Unit-0-lite)
-1. `fly deploy --config fly.toml` (builds the CUDA image, boots an A10).
-2. `python bench/run_bench.py --base-url https://uipe-vision-svc-bench.fly.dev`
+## ~~Ephemeral A10 benchmark~~ Benchmark (Unit-0-lite) — ⚠️ substrate AMENDED
+> Fly steps below are dead. The benchmark itself is substrate-agnostic — `run_bench.py`
+> takes `--base-url`, so point it at a Modal URL, the hosted-API service, or `localhost`.
+> Bring-up + teardown per substrate: [amendment](../specs/2026-06-08-phase2-substrate-pivot-amendment.md) §4 (Modal/hosted scale to zero — no `fly apps destroy`).
+1. ~~`fly deploy --config fly.toml`~~ Bring up the chosen substrate (Task 1′).
+2. `python bench/run_bench.py --base-url <substrate-url-or-localhost>`
    (first calls return status=warming while the model loads; the runner retries).
 3. Read the scorecard; PASS = mean interactable recall >= 0.80 and p95 latency <= 8000ms.
-4. `fly apps destroy uipe-vision-svc-bench --yes` to stop billing.
+4. ~~`fly apps destroy …`~~ Teardown is substrate-specific (scale-to-zero = nothing to do).
 
 If Qwen FAILS the bar, add InternVL2.5 / Florence-2 (swap VISION_MODEL_ID), re-run,
 pick the best — or ship vision-degraded (structural-only) per the spec escape hatch.
@@ -1308,7 +1325,9 @@ git commit -m "feat(vision-svc): golden set + run_bench.py eval runner + runbook
 
 ---
 
-## Task 12: Ephemeral deploy → Unit-0-lite bench → golden eval → teardown (ops)
+## Task 12: ~~Ephemeral [Fly] deploy~~ → bench → golden eval → (teardown) — ⚠️ SUPERSEDED → Task 12′
+
+> **Fly is dead.** Replaced by **Task 12′** in the [amendment](../specs/2026-06-08-phase2-substrate-pivot-amendment.md) §4 — same shape (deploy → bench → score → record) on the chosen substrate, minus Fly spin-up/`fly apps destroy` (scale-to-zero). Blocked on the §3 substrate decision + the golden set TODO. Original Fly steps kept as the decision trail.
 
 Not TDD — the real-GPU validation. This is where Qwen is confirmed (or challenged) on actual screenshots.
 

--- a/docs/superpowers/specs/2026-05-31-personal-gpu-deploy-design.md
+++ b/docs/superpowers/specs/2026-05-31-personal-gpu-deploy-design.md
@@ -1,8 +1,17 @@
-# Personal GPU Deploy — UIPE on Fly (scoped sibling of MCPaaSTA)
+# Personal GPU Deploy — ~~UIPE on Fly~~ (scoped sibling of MCPaaSTA)
 
 **Date:** 2026-05-31
-**Status:** Design — approved in brainstorm, pending implementation plan
+**Status:** Design — Phase 1 (monorepo) + Phase 2 (vision-svc CPU slice) shipped. **⚠️ Substrate AMENDED 2026-06-08 — Fly is dead.**
 **Parent spec:** [`2026-04-14-mcpaasta-design.md`](2026-04-14-mcpaasta-design.md) — this design **inherits** the parent's infrastructure decisions and **defers** its product layer.
+
+> **⚠️ "UIPE on Fly" is SUPERSEDED — see [`2026-06-08-phase2-substrate-pivot-amendment.md`](2026-06-08-phase2-substrate-pivot-amendment.md).**
+> Fly deprecated its GPUs (gone after 2026-07-31), so **Fly is abandoned for all phases.**
+> Decision **D2 ("Hosting platform = Fly.io") is dead**; the substrate is now PENDING
+> (hosted API / Modal / used-3090 rig). The whole `infra/fly/` layer, the Fly egress-CIDR
+> firewall, private-net routing, and Fly-secret bearer auth are **deferred to a Phase 4
+> re-spec** against the chosen substrate. The architecture (session-host + vision-svc
+> boundary, the `/v1` contract, two-tier vision, SSRF app-layer defense) is substrate-
+> independent and stands.
 
 ## Overview
 

--- a/docs/superpowers/specs/2026-06-07-personal-gpu-deploy-phase2-vision-svc-design.md
+++ b/docs/superpowers/specs/2026-06-07-personal-gpu-deploy-phase2-vision-svc-design.md
@@ -1,8 +1,15 @@
 # Phase 2 — `vision-svc` (Qwen analyze track)
 
 **Date:** 2026-06-07
-**Status:** Design — approved in brainstorm, pending implementation plan
+**Status:** Design — CPU slice implemented (PR #22/#23). **⚠️ Substrate AMENDED 2026-06-08.**
 **Parent spec:** [`2026-05-31-personal-gpu-deploy-design.md`](2026-05-31-personal-gpu-deploy-design.md) — this is the detailed design for that spec's **Phase 2**. It inherits all locked program decisions (Fly.io, Qwen2.5-VL-7B, two-tier vision, A10, on-demand GPU, bearer auth, SSRF defense) and does **not** re-litigate them.
+
+> **⚠️ SUPERSEDED (substrate only) — see [`2026-06-08-phase2-substrate-pivot-amendment.md`](2026-06-08-phase2-substrate-pivot-amendment.md).**
+> Fly killed its GPUs (deprecated, gone after 2026-07-31). **Fly is dead as a substrate.**
+> Everywhere this doc says "Fly", "A10", "ephemeral deploy", "approval/capacity gate", the
+> amendment overrides it (substrate is now PENDING: hosted API / Modal / used-3090 rig).
+> The contract, status/reason enum, classification ladder, fixtures, and `mapping.py` are
+> **unchanged** — the pivot is substrate-only.
 
 ## Overview
 
@@ -30,7 +37,7 @@ This phase delivers a validated, contract-tested vision service in isolation. It
 
 | # | Decision | Rationale |
 |---|---|---|
-| P2-1 | **GPU substrate = ephemeral Fly A10** (spin up → bench/eval → tear down) | Same substrate as the eventual production target; knocks out the Fly A10 availability prereq now. |
+| P2-1 | ~~**GPU substrate = ephemeral Fly A10**~~ **⚠️ SUPERSEDED** → substrate PENDING (hosted API / Modal / 3090); see [amendment](2026-06-08-phase2-substrate-pivot-amendment.md) §3–4 | Fly deprecated GPUs. The backend is now a config flag (`VISION_BACKEND`) across 3 pluggable analyzers, so the substrate is no longer load-bearing on the contract. |
 | P2-2 | **VLM analyze track only**; optical-flow CUDA-EP port → its own phase | One model type at a time; cleanest vertical slice; least GPU cost per iteration. |
 | P2-3 | **Qwen-first benchmark**; challenge with InternVL2.5/Florence-2 only if Qwen misses the bar | Qwen is the inherited default; least GPU cost; vision-degraded escape hatch covers total failure. |
 | P2-4 | **Detection-shaped `/v1/analyze` response** (`elements[]` + status); `VisualUnderstanding` deferred to Phase 3 | Smallest stable surface; additive-safe per the contract rule; golden eval scores element labels. |
@@ -63,7 +70,7 @@ packages/contracts/             # EXTENDED
 
 `sidecar/omniparser/` is **untouched** in Phase 2 (it is removed in Phase 3 when the pipeline stops consuming it). `vision-svc` is new and parallel.
 
-**Toolchain note:** `vision-svc` runs on Fly's Linux + CUDA A10, so it is **free of the torch 2.2.2 x86-macOS pin** that constrains the OmniParser sidecar (that pin is a Mac-hardware limit, not a code limit). It uses a current torch on a CUDA base image. `torch.load(weights_only=True)` is still enforced everywhere (carries forward the accepted-risk mitigation). A10's 24 GB VRAM fits a 7B VLM in fp16 (~16 GB) with headroom.
+**Toolchain note:** `vision-svc` runs on the chosen CUDA substrate (Modal or a local 3090) ~~Fly's Linux + CUDA A10~~ — Linux + CUDA either way — so it is **free of the torch 2.2.2 x86-macOS pin** that constrains the OmniParser sidecar (that pin is a Mac-hardware limit, not a code limit). It uses a current torch on a CUDA base image. `torch.load(weights_only=True)` is still enforced everywhere (carries forward the accepted-risk mitigation). A 24 GB card (A10/L4/3090) fits a 7B VLM in fp16 (~16 GB) with headroom — bench VRAM for KV/high-res before locking (see [amendment](2026-06-08-phase2-substrate-pivot-amendment.md) §3 caveats). The hosted-API backend needs no GPU at all.
 
 ## The `/v1/analyze` contract
 

--- a/docs/superpowers/specs/2026-06-08-phase2-substrate-pivot-amendment.md
+++ b/docs/superpowers/specs/2026-06-08-phase2-substrate-pivot-amendment.md
@@ -1,0 +1,200 @@
+# Amendment — Phase 2 substrate pivot (Fly is dead)
+
+**Date:** 2026-06-08
+**Status:** Active amendment — **substrate choice PENDING (Dirk's call, no rush)**
+**Amends:**
+- [`2026-05-31-personal-gpu-deploy-design.md`](2026-05-31-personal-gpu-deploy-design.md) — program spec (was "UIPE on Fly")
+- [`2026-06-07-personal-gpu-deploy-phase2-vision-svc-design.md`](2026-06-07-personal-gpu-deploy-phase2-vision-svc-design.md) — Phase 2 design
+- [`../plans/2026-06-07-personal-gpu-deploy-phase2-vision-svc.md`](../plans/2026-06-07-personal-gpu-deploy-phase2-vision-svc.md) — Phase 2 plan
+
+This document is the **live source of truth** for everything substrate-related in the
+three docs above. Where they say "Fly", "A10", "approval gate", "ephemeral A10
+deploy", or name Tasks 1 / 9 / 12, **this amendment overrides them.** Those docs keep
+their original text as the decision trail; the Fly-specific work items are marked
+`⚠️ SUPERSEDED` inline and replaced here.
+
+---
+
+## 1. Why this amendment exists
+
+Fly.io is **no longer a viable GPU substrate** — for any phase, not just the earlier
+approval gate.
+
+- The Phase-2 deploy attempt hit the org capacity gate: *"organization is not allowed
+  to use GPU machines."*
+- Fly billing's reply: **Fly GPUs are deprecated and gone after July 31 2026**
+  ([announcement](https://community.fly.io/t/gpu-migration-fly-io-gpus-will-be-deprecated-as-of-july-31-2026/27110),
+  [blog](https://fly.io/blog/wrong-about-gpu/)).
+
+So the program-spec premise ("UIPE on Fly") and every Fly-locked decision (program-spec
+D2 = "Hosting platform = Fly.io"; Phase-2 P2-1 = "ephemeral Fly A10") are dead. The
+two criteria Fly burned us on — **vendor stability (GPU as a core business, not a side
+bet)** and **no approval gate** — now dominate substrate selection. `flyctl` v0.4.58 is
+installed but unused.
+
+## 2. What still stands (NOT affected by the pivot)
+
+The pivot is **substrate-only**. Everything the contract/CPU work produced is
+substrate-independent and already merged:
+
+- **PR #22** (CPU impl, Tasks 2–10) merged to `master`: `@uipe/contracts` `/v1`
+  snake_case schema + zod, cross-language JSON fixtures (zod + Pydantic), the
+  `packages/vision-svc/` Python package (config, schema, mapping, FastAPI handler +
+  status/reason classification ladder, lazy analyzer, bench scoring). 26 CPU pytest +
+  contracts green.
+- **PR #23** (this branch) merged to `master`: `HostedApiAnalyzer` + 3 research reports
+  + `run_bench.py`/README. 30/30 vision-svc pytest.
+- **The `/v1/analyze` contract, the status/reason enum, the classification ladder, the
+  fixture-driven cross-language tests, `mapping.py`** — all unchanged. The substrate
+  does not touch the wire format.
+- **Three pluggable analyzer backends** (the duck-typed `Analyzer` protocol makes the
+  substrate a **config flag, not a rewrite**):
+  - `HostedApiAnalyzer` — OpenAI-compatible hosted VLM (Hyperbolic / DeepInfra /
+    OpenRouter). No GPU, runs anywhere incl. the Intel Mac. `app/hosted.py`.
+  - `QwenAnalyzer` — CUDA. Runs unchanged on Modal **or** a local 3090. `app/qwen.py`.
+  - `MlxAnalyzer` — Apple Silicon only. **Not built** (sketch at
+    `docs/research/2026-06-07-qwen25vl-apple-silicon-mlx-sketch.py`).
+  - Switch: `VISION_BACKEND=hosted|qwen` in `build_default_app` (`app/main.py`).
+
+The `Dockerfile` stays as the portable CUDA reference image (works on Modal and a 3090
+unchanged); only `fly.toml` is now dead.
+
+## 3. The substrate decision (matrix — choice PENDING)
+
+Research ran as 3 parallel workflows on 2026-06-07; full reports in
+`docs/superpowers/research/`. Honest framing up front: **at UIPE's volume (single-tenant,
+intermittent, a few hundred screenshots/day) cloud is ~$0–3/mo and a homelab NEVER
+breaks even on cost.** The homelab is a *privacy / independence / learning* bet, not a
+savings play. Don't justify hardware as cloud savings — that math never closes.
+
+### 3a. The three live options
+
+| Option | What it is | $ at our volume | CUDA for optical-flow later? | No-rewrite? | Key caveat |
+|---|---|---|---|---|---|
+| **Hosted API** (built, ready now) | `HostedApiAnalyzer` → Hyperbolic / DeepInfra / OpenRouter | **~$3.42/mo** (Hyperbolic ~$0.20/M tok); OpenRouter free 7B for throwaway | ❌ token API can't serve optical-flow | ✅ already built | No weight/version control (eval drift); screenshots leave the boundary |
+| **Modal** (cloud serverless) | Declarative GPU in a `@function`/ASGI decorator; `QwenAnalyzer` runs as-is | **~$0–10/mo** ($30/mo free credit ~zeroes it; A10 $1.10/hr, L4 $0.80/hr, idle=$0) | ✅ same substrate serves both tracks | ✅ near-verbatim FastAPI | Cold-start on each burst (snapshots mitigate; benchmark the 7B before Phase 4) |
+| **Used RTX 3090 rig** (homelab) | DIY x86_64 CUDA-12 tower, 24 GB | **~$1,950 up front**, then electricity | ✅ frictionless — `ort`/RAFT + bitsandbytes LoRA just pip-install | ✅ `qwen.py` runs unchanged | Never pays back vs cloud; noise/heat (undervolt, repad, site in a closet) |
+
+**Decision matrix detail (from the research):**
+
+- **Cloud serverless ranking:** **#1 Modal** — the only substrate that maxes every
+  weighted criterion at once: verified scale-to-zero by default, verified **no approval
+  gate** (free Starter ships 10 GPU concurrency, only a Stripe card required), strongest
+  stability ($355M Series C @ $4.65B, ~$300M ARR, **GPU inference IS the product**), 24 GB
+  A10/L4 self-serve, $30/mo credit, best FastAPI DX. **#2 RunPod Serverless** (verified
+  scale-to-zero, ~$0.68/hr, same account gives raw CUDA Pods for optical-flow; loses on
+  billed cold-starts, no free credit, handler-wrapper porting, seed-stage). #3 Cloud Run
+  GPU, #4 Baseten, #5 Cerebrium. **Avoid: Azure ACA, Fal-custom — real approval gates
+  (Fly-shaped).**
+- **Homelab ranking:** **#1 used RTX 3090 (24 GB) ~$1,950** — cheapest *frictionless*
+  CUDA; the boring x86 discrete-GPU path that "just works" for `ort`/RAFT + LoRA;
+  upgradeable to 48 GB with a 2nd card. **Runner-up DGX Spark $4,699** (128 GB unified,
+  near-silent, but aarch64/sm_121/CUDA-13 forces an ORT **source-build** that lands right
+  on the optical-flow sidecar). Parts list in the homelab report.
+- **Apple Silicon:** runs the VLM beautifully (MLX) and *most* of the roadmap
+  (optical-flow via ORT **CoreML EP** — the "RAFT grid_sample can't do CoreML" claim is a
+  **myth** for the MLProgram path), but has **no CUDA** for full training / CUDA-EP perf
+  benchmarks. Buy a Mac only if it's a dev machine you'd want anyway (then the marginal
+  "GPU" cost is the RAM upgrade). Not a recommendation to buy hardware *for UIPE*.
+
+### 3b. Recommended sequence (research's strategic call — NOT a committed decision)
+
+The optical-flow roadmap, not cost, breaks the tie. A token API can serve `analyze`
+cheaply forever but **fundamentally cannot serve the optical-flow CUDA track** — so a
+self-host substrate is eventually non-optional. Given that:
+
+1. **Now (validate Phase 2):** run the eval on the **hosted API** — already built, idle=$0,
+   no GPU ceremony. Hyperbolic/DeepInfra for the real 7B; OpenRouter's free 7B for
+   throwaway A/B + provider failover.
+2. **When you need your own `/v1/analyze` detection-shaped output that a token API won't
+   give, OR the optical-flow CUDA port begins:** stand up **Modal** (cloud) so both tracks
+   share one stable, no-gate, scale-to-zero substrate — *or* buy the **3090 rig** if you
+   want to own the box (privacy/independence/learning).
+
+**This is a recommendation, not a lock.** The hardware purchase is Dirk's to mull, no
+rush. The amendment stays substrate-agnostic until he picks; §4 below works for whichever
+he chooses.
+
+## 4. Substrate-agnostic deploy plan (replaces Fly Tasks 1 / 9 / 12)
+
+The old plan's three ops tasks were Fly-specific. Replacements below are written so the
+**body is identical regardless of substrate** and only a per-substrate "bring-up"
+appendix differs. None of these are started; they cost money/hardware, so they wait on
+the §3 decision.
+
+### Task 1′ — Substrate bring-up (replaces "Fly A10 capacity/region gate")
+
+The old Task 1 verified Fly A10 capacity. The pivot's equivalent is: **stand up the
+chosen substrate and confirm a 24 GB-class CUDA GPU (or hosted endpoint) answers a
+trivial inference.** Pick one bring-up path:
+
+- **Hosted API:** get a provider key → set `VISION_BACKEND=hosted`,
+  `VISION_API_KEY=…`, `VISION_HOSTED_BASE_URL`, `VISION_HOSTED_MODEL` → no capacity gate
+  exists. Done when `/v1/health` is ready and one screenshot round-trips.
+- **Modal:** `modal token new` (Stripe card on file; no approval gate) → wrap the FastAPI
+  app in a Modal ASGI function requesting an A10/L4 → `modal deploy`. Done when the
+  deployed URL serves `/v1/health` and a cold `/v1/analyze` returns within the warming
+  budget. Benchmark the real 7B cold-start before relying on it for Phase 4.
+- **3090 rig:** assemble the box, install CUDA-12 + the model deps, run `app/qwen.py`
+  locally (CUDA, unchanged). Done when `nvidia-smi` shows the card and `/v1/analyze`
+  returns on a real screenshot.
+
+**Acceptance:** a reachable `/v1/analyze` (cloud URL or `localhost`) returns a valid
+`VisionAnalyzeResponse` for one golden screenshot. No `fly.toml`, no capacity escalation
+path needed (Modal/hosted have no gate; the 3090 is owned hardware).
+
+### Task 9′ — Deploy config (replaces "Dockerfile (CUDA) + Fly config")
+
+The CUDA `Dockerfile` **stays** as the portable reference image. The Fly-specific
+`fly.toml` is **dead** — leave it in the tree as a historical artifact or delete it
+(low stakes; it's 254 bytes). The replacement config is per-substrate:
+
+- **Hosted API:** no image, no infra config — just env vars.
+- **Modal:** a small `modal_app.py` (the `@app.function(gpu="A10G")` + `@modal.asgi_app`
+  wrapper returning `create_app(QwenAnalyzer(cfg))`). Reuses the `Dockerfile`/requirements
+  via `modal.Image.from_dockerfile(...)` or an equivalent image spec.
+- **3090 rig:** a `systemd` unit (or `docker run --gpus all`) running
+  `uvicorn app.main:app` against the local card. Reuses the `Dockerfile` directly.
+
+### Task 12′ — Deploy → Unit-0-lite bench → golden eval → (teardown) (replaces the ephemeral Fly deploy)
+
+Same shape as the old Task 12, minus Fly's spin-up/`fly apps destroy` teardown:
+
+1. Bring up the substrate (Task 1′).
+2. `python bench/run_bench.py --base-url <substrate-url-or-localhost>` against the golden
+   set (golden set is still a TODO — see §5).
+3. Score; record the model decision + scorecard in `bench/SCORECARD.md`.
+4. **Teardown is substrate-specific:** Modal/hosted scale to zero automatically (no
+   `fly apps destroy` step — idle = $0); the 3090 just idles. The "destroy to stop
+   billing" step from the Fly plan **no longer applies**.
+
+`run_bench.py` is already substrate-agnostic — it takes `--base-url`, so it points at a
+Modal URL, a hosted gateway (via the service), or `localhost` with no code change.
+
+## 5. Still TODO (unchanged by the pivot)
+
+- **Golden set** for the scored eval (`bench/golden/` + `expected/*.json`) — ~10–20 real
+  UIPE screenshots hand-labeled with expected elements. Blocked until a model is actually
+  running (any backend). Reuse `landing/screenshots/` + engine fixtures as the seed.
+- **The actual deploy + eval run** (Task 12′) — waits on the §3 substrate decision.
+- **Phases 3 (pipeline adaptation) and 4 (session-host + persistent deploy + egress)** —
+  still high-level only. The Fly-specific parts of the program spec (private-net routing,
+  Fly egress CIDR firewall, Fly secrets for the bearer token) need their own re-spec
+  against the chosen substrate when Phase 4 starts. The SSRF *app-layer* defense is
+  substrate-independent and stands; the *network-layer* egress firewall was Fly-specific
+  and must be re-designed for the new substrate.
+
+## 6. Decision-record deltas (what changed in the amended docs)
+
+| Original | Status after this amendment |
+|---|---|
+| Program-spec **D2** "Hosting platform = Fly.io" | **Superseded** — substrate PENDING (§3). |
+| Phase-2 **P2-1** "GPU substrate = ephemeral Fly A10" | **Superseded** — replaced by §3 matrix + §4 substrate-agnostic plan. |
+| Phase-2 spec toolchain note "runs on Fly's Linux + CUDA A10" | **Amended** — runs on the chosen CUDA substrate (Modal/3090) or a hosted API; still free of the torch-2.2.2 Mac pin; `weights_only=True` still enforced. |
+| Plan **Task 1** (Fly A10 capacity gate) | **Superseded** → Task 1′ (§4). |
+| Plan **Task 9** (Dockerfile + `fly.toml`) | **Amended** — Dockerfile stays; `fly.toml` dead → Task 9′ (§4). |
+| Plan **Task 12** (ephemeral Fly deploy + `fly apps destroy`) | **Superseded** → Task 12′ (§4); teardown step removed (scale-to-zero). |
+| Program-spec Fly egress CIDR firewall / private net / Fly secrets | **Deferred to Phase 4 re-spec** against the new substrate (§5). |
+
+All other Phase-2 decisions (P2-2 … P2-6, the contract, the classification ladder, the
+testing posture) are **unchanged**.

--- a/packages/vision-svc/bench/run_bench.py
+++ b/packages/vision-svc/bench/run_bench.py
@@ -1,8 +1,9 @@
 """Unit-0-lite: POST each golden screenshot to a running /v1/analyze, score the
-result against the hand-labeled expectations, print a scorecard. Run against an
-ephemeral Fly A10 deploy (Task 12) — dogfoods the real contract + serve path.
+result against the hand-labeled expectations, print a scorecard. Run against the
+chosen GPU substrate (Modal / 3090) or a hosted VLM API — dogfoods the real
+contract + serve path. See docs substrate-pivot amendment, Task 12'.
 
-Usage: python bench/run_bench.py --base-url https://<app>.fly.dev
+Usage: python bench/run_bench.py --base-url <substrate-url-or-localhost>
 """
 import argparse
 import base64


### PR DESCRIPTION
## What

Fly.io deprecated its GPUs (gone after 2026-07-31) and gated existing orgs out — so **Fly is dead as a GPU substrate for every phase**, not just the earlier approval gate. This documents the pivot.

A single canonical **amendment** becomes the live source of truth for everything substrate-related; the three pre-existing planning docs keep their original Fly text but get `⚠️ SUPERSEDED` banners + inline notes pointing at the amendment. **Superseded, not deleted** — the decision trail stays intact.

## Files

- **New** `docs/superpowers/specs/2026-06-08-phase2-substrate-pivot-amendment.md` — Fly-dead rationale; **3-option decision matrix** (hosted API ~$3.42/mo · Modal ~$0–10/mo · used-3090 rig ~$1,950) with the **choice marked PENDING**; substrate-agnostic **Task 1′/9′/12′** replacing the Fly ops tasks; decision-record deltas table.
- `…/specs/2026-05-31-personal-gpu-deploy-design.md` — banner; D2 (Fly hosting) marked dead.
- `…/specs/2026-06-07-personal-gpu-deploy-phase2-vision-svc-design.md` — banner; P2-1 + toolchain note amended.
- `…/plans/2026-06-07-personal-gpu-deploy-phase2-vision-svc.md` — banner; Tasks 1/9/12 + ephemeral-bench section marked superseded.

## Not in scope (unchanged)

The contract (`/v1`), status/reason enum, classification ladder, fixtures, and `mapping.py` are untouched — the pivot is **substrate-only**. The 3 pluggable analyzer backends (hosted/qwen/mlx) already make the substrate a config flag.

## Open decision (Dirk's call, no rush)

Substrate choice: **hosted API** (built, validate now) → **Modal** (cloud, scale-to-zero) or a **used-3090 rig** (homelab, own it) when the optical-flow CUDA track begins. Hardware purchase is deliberately not assumed.
