### PR TITLE
security(track 3): sidecar & vision-svc hardening — loopback bind, size caps, weight pinning, bearer auth

### DIFF
--- a/packages/vision-svc/app/images.py
+++ b/packages/vision-svc/app/images.py
@@ -1,0 +1,29 @@
+"""Bounded PNG decoding for any analyzer that rasterizes a request.
+
+Pillow will expand a few KB of compressed data into gigabytes of pixels, so
+decoding goes through here instead of calling Image.open at the call site.
+The size check runs against the header, before any pixel data is decoded.
+"""
+import base64
+import io
+
+from PIL import Image
+
+# Pillow warns past MAX_IMAGE_PIXELS and raises past 2x it. Keep that ceiling
+# above our own limit so our check is the one that reports the failure.
+Image.MAX_IMAGE_PIXELS = 4096 * 4096
+MAX_PIXELS = 3840 * 2160  # 4K
+
+
+def decode_png(png_base64: str) -> Image.Image:
+    """Decode base64 image data to RGB, refusing anything past the pixel ceiling."""
+    try:
+        raw = base64.b64decode(png_base64, validate=True)
+    except Exception as e:
+        raise ValueError(f"invalid base64: {e}") from e
+
+    image = Image.open(io.BytesIO(raw))  # lazy: .size reads the header only
+    width, height = image.size
+    if width * height > MAX_PIXELS:
+        raise ValueError(f"image exceeds max dimensions: {width}x{height}")
+    return image.convert("RGB")

--- a/packages/vision-svc/app/main.py
+++ b/packages/vision-svc/app/main.py
@@ -1,10 +1,12 @@
 import asyncio
+import hmac
 import logging
+import os
 import time
 import uuid
-from typing import Protocol
+from typing import Optional, Protocol
 
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Header, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
@@ -13,6 +15,22 @@ from app.mapping import parse_detection_output
 from app.schema import VisionAnalyzeRequest, VisionAnalyzeResponse
 
 log = logging.getLogger("vision-svc")
+
+
+def _require_bearer(authorization: Optional[str] = Header(default=None)) -> None:
+    """Gate /v1/analyze when VISION_SVC_TOKEN is set.
+
+    Read at request time, not app-build time, so the service picks up the
+    environment it is actually running under. With no token configured the
+    endpoint stays open, which keeps purely-local single-tenant use working.
+    """
+    token = os.environ.get("VISION_SVC_TOKEN")
+    if not token:
+        return
+    expected = f"Bearer {token}"
+    # compare_digest: constant time, so a wrong token leaks no prefix length
+    if authorization is None or not hmac.compare_digest(authorization, expected):
+        raise HTTPException(status_code=401, detail="invalid or missing bearer token")
 
 
 class Analyzer(Protocol):
@@ -40,7 +58,7 @@ def create_app(analyzer: Analyzer, timeout_s: float | None = None) -> FastAPI:
     async def health():
         return {"ready": analyzer.ready, "model_id": analyzer.model_id}
 
-    @app.post("/v1/analyze")
+    @app.post("/v1/analyze", dependencies=[Depends(_require_bearer)])
     async def analyze(req: VisionAnalyzeRequest) -> VisionAnalyzeResponse:
         rid = req.request_id or str(uuid.uuid4())
 
@@ -78,8 +96,6 @@ def create_app(analyzer: Analyzer, timeout_s: float | None = None) -> FastAPI:
 
 
 def build_default_app() -> FastAPI:
-    import os
-
     cfg = Config.from_env(os.environ)
     backend = os.environ.get("VISION_BACKEND", "qwen")
     if backend == "hosted":

--- a/packages/vision-svc/app/qwen.py
+++ b/packages/vision-svc/app/qwen.py
@@ -2,8 +2,8 @@ import asyncio
 import base64
 import io
 import threading
-from PIL import Image
 from app.config import Config
+from app.images import decode_png
 from app.prompt import DETECTION_PROMPT
 
 
@@ -41,7 +41,7 @@ class QwenAnalyzer:
     def _infer_sync(self, png_base64: str) -> str:
         from qwen_vl_utils import process_vision_info
 
-        image = Image.open(io.BytesIO(base64.b64decode(png_base64))).convert("RGB")
+        image = decode_png(png_base64)
         messages = [{"role": "user", "content": [
             {"type": "image", "image": image},
             {"type": "text", "text": DETECTION_PROMPT},

--- a/packages/vision-svc/app/schema.py
+++ b/packages/vision-svc/app/schema.py
@@ -1,5 +1,12 @@
+import math
 from typing import Literal, Optional
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+# A 1280x720 lossless PNG sits far under 4 MB, so a 16 MB base64 ceiling leaves
+# 4K headroom while still bounding what one request can make us allocate.
+MAX_PNG_BASE64 = 16_000_000
+MAX_REGIONS = 64
+MAX_REQUEST_ID = 200
 
 VisionStatus = Literal["ok", "warming", "degraded"]
 VisionReason = Literal["model_loading", "inference_timeout", "inference_error", "unreachable"]
@@ -10,6 +17,14 @@ class BBox(BaseModel):
     y: float
     w: float
     h: float
+
+    @field_validator("x", "y", "w", "h")
+    @classmethod
+    def _finite(cls, v: float) -> float:
+        # inf/nan propagate silently through downstream geometry instead of failing
+        if not math.isfinite(v):
+            raise ValueError("coordinate must be finite")
+        return v
 
 
 class VisionElement(BaseModel):
@@ -23,9 +38,9 @@ class VisionElement(BaseModel):
 
 class VisionAnalyzeRequest(BaseModel):
     api_version: Literal["v1"]
-    png_base64: str
-    regions: list[BBox]
-    request_id: Optional[str] = None
+    png_base64: str = Field(max_length=MAX_PNG_BASE64)
+    regions: list[BBox] = Field(max_length=MAX_REGIONS)
+    request_id: Optional[str] = Field(default=None, max_length=MAX_REQUEST_ID)
 
 
 class VisionAnalyzeResponse(BaseModel):

--- a/packages/vision-svc/bench/run_bench.py
+++ b/packages/vision-svc/bench/run_bench.py
@@ -8,6 +8,7 @@ Usage: python bench/run_bench.py --base-url <substrate-url-or-localhost>
 import argparse
 import base64
 import json
+import os
 import sys
 import time
 from pathlib import Path
@@ -23,8 +24,11 @@ P95_LATENCY_MS_BAR = 8000
 
 def _post(base_url: str, png_b64: str) -> dict:
     body = json.dumps({"api_version": "v1", "png_base64": png_b64, "regions": []}).encode()
-    req = urllib.request.Request(f"{base_url}/v1/analyze", data=body,
-                                 headers={"Content-Type": "application/json"})
+    headers = {"Content-Type": "application/json"}
+    token = os.environ.get("VISION_SVC_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(f"{base_url}/v1/analyze", data=body, headers=headers)
     with urllib.request.urlopen(req, timeout=60) as r:
         return json.loads(r.read())
 

--- a/packages/vision-svc/tests/test_auth.py
+++ b/packages/vision-svc/tests/test_auth.py
@@ -1,0 +1,53 @@
+"""Optional bearer auth on /v1/analyze (vsv-6). Phase-4 gate, seeded early."""
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+_REQ = {"api_version": "v1", "png_base64": "aaaa", "regions": []}
+
+
+class _Stub:
+    model_id = "stub"
+
+    @property
+    def ready(self):
+        return True
+
+    async def infer(self, png_base64, regions):
+        return "[]"
+
+
+def _client():
+    return TestClient(create_app(_Stub()))
+
+
+def test_rejects_missing_header_when_token_set(monkeypatch):
+    monkeypatch.setenv("VISION_SVC_TOKEN", "secret")
+    assert _client().post("/v1/analyze", json=_REQ).status_code == 401
+
+
+def test_rejects_wrong_token(monkeypatch):
+    monkeypatch.setenv("VISION_SVC_TOKEN", "secret")
+    resp = _client().post(
+        "/v1/analyze", headers={"Authorization": "Bearer wrong"}, json=_REQ
+    )
+    assert resp.status_code == 401
+
+
+def test_accepts_correct_token(monkeypatch):
+    monkeypatch.setenv("VISION_SVC_TOKEN", "secret")
+    resp = _client().post(
+        "/v1/analyze", headers={"Authorization": "Bearer secret"}, json=_REQ
+    )
+    assert resp.status_code == 200
+
+
+def test_open_when_no_token_configured(monkeypatch):
+    # Back-compat: purely local single-tenant use stays unauthenticated.
+    monkeypatch.delenv("VISION_SVC_TOKEN", raising=False)
+    assert _client().post("/v1/analyze", json=_REQ).status_code == 200
+
+
+def test_health_stays_open_for_probes(monkeypatch):
+    monkeypatch.setenv("VISION_SVC_TOKEN", "secret")
+    assert _client().get("/v1/health").status_code == 200

--- a/packages/vision-svc/tests/test_images.py
+++ b/packages/vision-svc/tests/test_images.py
@@ -1,0 +1,36 @@
+import base64
+import io
+
+import pytest
+from PIL import Image
+
+from app import images
+
+
+def _png_b64(size=(8, 8)) -> str:
+    buf = io.BytesIO()
+    Image.new("RGB", size).save(buf, "PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def test_decodes_a_normal_png_to_rgb():
+    img = images.decode_png(_png_b64())
+    assert img.mode == "RGB"
+    assert img.size == (8, 8)
+
+
+def test_rejects_image_over_the_pixel_ceiling(monkeypatch):
+    # Rather than allocate a real 4K bomb, lower the ceiling under a small image.
+    monkeypatch.setattr(images, "MAX_PIXELS", 4)
+    with pytest.raises(ValueError, match="exceeds max dimensions"):
+        images.decode_png(_png_b64((8, 8)))
+
+
+def test_rejects_invalid_base64():
+    with pytest.raises(ValueError, match="invalid base64"):
+        images.decode_png("!!!not base64!!!")
+
+
+def test_rejects_non_image_payload():
+    with pytest.raises(Exception):
+        images.decode_png(base64.b64encode(b"plain text, not a png").decode())

--- a/packages/vision-svc/tests/test_schema_fixtures.py
+++ b/packages/vision-svc/tests/test_schema_fixtures.py
@@ -1,3 +1,4 @@
+import base64
 import json
 from pathlib import Path
 import pytest
@@ -26,3 +27,42 @@ def test_invalid_response_missing_reason_rejected():
 def test_invalid_request_bad_version_rejected():
     with pytest.raises(ValidationError):
         VisionAnalyzeRequest.model_validate(_load("analyze.request.invalid-bad-version.json"))
+
+
+# --- Track 3 / Task 3.2: request size caps (vsv-1, vsv-2, vsv-3) ---
+
+def test_png_base64_size_capped():
+    huge = base64.b64encode(b"\x00" * (20 * 1024 * 1024)).decode()
+    with pytest.raises(ValidationError):
+        VisionAnalyzeRequest(api_version="v1", png_base64=huge, regions=[])
+
+
+def test_regions_count_capped():
+    with pytest.raises(ValidationError):
+        VisionAnalyzeRequest(
+            api_version="v1", png_base64="aaaa",
+            regions=[{"x": 0, "y": 0, "w": 1, "h": 1}] * 1000,
+        )
+
+
+def test_bbox_rejects_non_finite_coords():
+    with pytest.raises(ValidationError):
+        VisionAnalyzeRequest(
+            api_version="v1", png_base64="aaaa",
+            regions=[{"x": float("inf"), "y": 0, "w": 1, "h": 1}],
+        )
+
+
+def test_request_id_length_capped():
+    with pytest.raises(ValidationError):
+        VisionAnalyzeRequest(
+            api_version="v1", png_base64="aaaa", regions=[], request_id="x" * 500,
+        )
+
+
+def test_normal_request_still_accepted():
+    req = VisionAnalyzeRequest(
+        api_version="v1", png_base64="aaaa",
+        regions=[{"x": 0, "y": 0, "w": 10, "h": 10}], request_id="abc",
+    )
+    assert len(req.regions) == 1

--- a/sidecar/omniparser/README.md
+++ b/sidecar/omniparser/README.md
@@ -33,8 +33,27 @@ pip install -r requirements.txt
 mkdir -p weights/icon_detect weights/icon_caption_florence
 
 # Download from HuggingFace (microsoft/OmniParser-v2.0)
-huggingface-cli download microsoft/OmniParser-v2.0 --local-dir weights/
+# Pinned revision: the sidecar unpickles these weights, so the artifact must be
+# the exact one that was reviewed. Do not drop --revision.
+huggingface-cli download microsoft/OmniParser-v2.0 \
+  --revision 6600256cb0f1b07651e3bc86166196307bad7e2d \
+  --local-dir weights/
 ```
+
+`main.py` verifies the YOLO checkpoint at startup and refuses to load on a
+mismatch:
+
+| File | SHA-256 |
+|---|---|
+| `weights/icon_detect/model.pt` | `dab3d4351ad00b035db829909a4db98354d5a90f6990e4ac00222a9a95d4bf57` |
+
+If you re-pin to a newer revision, update `_YOLO_SHA256` in `main.py` in the
+same commit, and say why in the message.
+
+The Florence-2 processor is pinned to revision
+`5ca5edf5bd017b9919c05d08aebef5e4c7ac3bac`. That call still passes
+`trust_remote_code=True` — see the comment in `main.py` for why it cannot be
+dropped for this checkpoint yet.
 
 The weights directory should look like:
 

--- a/sidecar/omniparser/main.py
+++ b/sidecar/omniparser/main.py
@@ -21,6 +21,11 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(title="OmniParser V2 Sidecar")
 
+# Pillow expands a few KB of compressed data into gigabytes of pixels unless
+# bounded. Keep MAX_IMAGE_PIXELS above our own limit so our check reports first.
+Image.MAX_IMAGE_PIXELS = 4096 * 4096
+MAX_PIXELS = 3840 * 2160  # 4K
+
 # Force CPU — no CUDA on this Intel Mac
 device = "cpu"
 
@@ -71,7 +76,10 @@ async def parse_screenshot(image: UploadFile = File(...)):
 
     try:
         img_bytes = await image.read()
-        img = Image.open(io.BytesIO(img_bytes)).convert("RGB")
+        img = Image.open(io.BytesIO(img_bytes))  # lazy: .size reads the header only
+        if img.size[0] * img.size[1] > MAX_PIXELS:
+            raise ValueError(f"image exceeds max dimensions: {img.size[0]}x{img.size[1]}")
+        img = img.convert("RGB")
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Invalid image: {e}")
 

--- a/sidecar/omniparser/main.py
+++ b/sidecar/omniparser/main.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 import uvicorn
 from PIL import Image
 import io
+import os
 import torch
 from ultralytics import YOLO
 from transformers import AutoProcessor, AutoModelForCausalLM
@@ -132,4 +133,8 @@ async def health():
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8100)
+    # Loopback by default. The sidecar has no auth of its own, so binding it
+    # off-host has to be a deliberate opt-in rather than the default.
+    host = os.environ.get("OMNIPARSER_HOST", "127.0.0.1")
+    port = int(os.environ.get("OMNIPARSER_PORT", "8100"))
+    uvicorn.run(app, host=host, port=port)

--- a/sidecar/omniparser/main.py
+++ b/sidecar/omniparser/main.py
@@ -9,8 +9,10 @@ from fastapi import FastAPI, File, UploadFile, HTTPException
 from fastapi.responses import JSONResponse
 import uvicorn
 from PIL import Image
+import hashlib
 import io
 import os
+import pathlib
 import torch
 from ultralytics import YOLO
 from transformers import AutoProcessor, AutoModelForCausalLM
@@ -23,6 +25,28 @@ app = FastAPI(title="OmniParser V2 Sidecar")
 
 # Pillow expands a few KB of compressed data into gigabytes of pixels unless
 # bounded. Keep MAX_IMAGE_PIXELS above our own limit so our check reports first.
+# Pinned upstream revision. trust_remote_code below executes code fetched from
+# this repo, so pinning the revision is what stops a future commit there from
+# running here. Re-pin deliberately, never float to main.
+FLORENCE_BASE_REVISION = "5ca5edf5bd017b9919c05d08aebef5e4c7ac3bac"
+
+# Loading an ultralytics .pt unpickles it, which executes arbitrary code. Refuse
+# anything but the exact reviewed artifact from OmniParser-v2.0's pinned revision.
+_YOLO_WEIGHTS = pathlib.Path("weights/icon_detect/model.pt")
+_YOLO_SHA256 = "dab3d4351ad00b035db829909a4db98354d5a90f6990e4ac00222a9a95d4bf57"
+
+
+def _verify_yolo_weights() -> None:
+    if not _YOLO_WEIGHTS.exists():
+        raise RuntimeError(f"YOLO weights missing at {_YOLO_WEIGHTS}")
+    digest = hashlib.sha256(_YOLO_WEIGHTS.read_bytes()).hexdigest()
+    if digest != _YOLO_SHA256:
+        raise RuntimeError(
+            "YOLO weights checksum mismatch — refusing to load. "
+            f"expected {_YOLO_SHA256}, got {digest}"
+        )
+
+
 Image.MAX_IMAGE_PIXELS = 4096 * 4096
 MAX_PIXELS = 3840 * 2160  # 4K
 
@@ -44,7 +68,8 @@ async def load_models():
 
     try:
         # YOLOv8 for element detection
-        yolo_model = YOLO("weights/icon_detect/model.pt")
+        _verify_yolo_weights()
+        yolo_model = YOLO(str(_YOLO_WEIGHTS))
         logger.info("YOLOv8 model loaded")
     except Exception as e:
         logger.error(f"Failed to load YOLOv8 model: {e}")
@@ -53,9 +78,16 @@ async def load_models():
     try:
         # Florence-2 for icon captioning
         # Processor from base repo (OmniParser weights don't include tokenizer files)
+        # trust_remote_code cannot be dropped here yet: OmniParser's fine-tuned
+        # checkpoint declares an inner text_config.model_type of "florence2_language",
+        # which transformers' native florence2 implementation does not know
+        # (KeyError on load), and native florence2 maps to ImageTextToText rather
+        # than CausalLM. Pinning the revision bounds the blast radius until the
+        # modeling file is vendored. See the security remediation plan, task 3.3.
         caption_processor = AutoProcessor.from_pretrained(
             "microsoft/Florence-2-base",
-            trust_remote_code=True
+            revision=FLORENCE_BASE_REVISION,
+            trust_remote_code=True,
         )
         # Model from local fine-tuned weights
         caption_model = AutoModelForCausalLM.from_pretrained(


### PR DESCRIPTION
Track 3 of the [security remediation plan](docs/superpowers/plans/2026-06-09-security-remediation.md), following tracks 1 (#25) and 2 (#26). Closes `omn-3`, `omn-4`, `vsv-1`, `vsv-2`, `vsv-3`, `omn-1`, `sec-2`, `vsv-6`. Leaves `omn-2` partly open — reasoning below.

Independent of #27; no overlapping files.

## Commits

| | |
|---|---|
| `62a07ee` | bind omniparser to loopback by default (`omn-3`) |
| `0485e80` | image size + decompression-bomb caps (`omn-4`, `vsv-1,2,3`) |
| `9bc8dcb` | optional bearer auth on vision-svc (`vsv-6`, Phase-4 gate) |
| `6c6e681` | pin + checksum weights, pin Florence-2 revision (`omn-1`, `omn-2` partial, `sec-2`) |

## What changed

**Loopback bind.** The sidecar has no authentication of its own, so listening on `0.0.0.0` exposed model inference to anything that could reach the host. Default is now `127.0.0.1`; binding wider is an explicit `OMNIPARSER_HOST` opt-in.

**Request caps.** `png_base64` is capped at 16 MB of base64 (a 1280x720 lossless PNG sits far under that, leaving 4K headroom), `regions` at 64, `request_id` at 200. `BBox` coordinates must be finite — `inf`/`nan` otherwise propagate silently through downstream geometry instead of failing at the boundary.

**Decompression bombs.** Decoding moved into `app/images.py`. The pixel-count check reads the PNG header *before* any pixel data is decoded, which is what actually stops the bomb. It is a separate module rather than inline in `qwen.py` because `qwen.py` imports torch, which isn't installed on this machine — a guard that can't be tested isn't much of a guard. The sidecar gets the same check inlined, since it's a separate service with its own venv.

**Bearer auth.** Set `VISION_SVC_TOKEN` and `/v1/analyze` requires a matching token; leave it unset and the endpoint stays open, so existing local use is unaffected. Read per-request rather than at app-build time, constant-time comparison. `/v1/health` stays open for probes. `run_bench.py` sends the header when the variable is present.

**Weight integrity.** Loading `weights/icon_detect/model.pt` unpickles it, which executes whatever the pickle says. Startup now verifies its SHA-256 and refuses to load on mismatch. The hash is confirmed twice: computed directly, and matching the HuggingFace cache blob name, which is itself the digest. The README download is pinned to revision `6600256c` so the artifact the checksum describes is the one you actually get.

## `omn-2` is only partly closed — the plan was wrong

Task 3.3 says to drop `trust_remote_code=True` because "Florence-2 has had native transformers support since 4.53". That holds for a stock Florence-2 and **not** for OmniParser's fine-tuned checkpoint. Verified against transformers 4.57.6 with the real weights:

- `AutoConfig.from_pretrained("weights/icon_caption_florence")` without the flag raises `KeyError: 'florence2_language'` — the checkpoint's inner `text_config.model_type` is the remote-code implementation's name, which native `florence2` does not recognise.
- `florence2` is registered for **ImageTextToText**, not CausalLM, while this code calls `AutoModelForCausalLM`. Even a loadable config would not resolve.

Dropping the flag therefore breaks the sidecar. Closing `omn-2` properly needs the modeling file vendored and audited into the repo, which is its own piece of work rather than something to bodge in here.

Mitigation shipped instead: the `microsoft/Florence-2-base` revision is pinned to `5ca5edf5`. Since `trust_remote_code` has to stay, pinning is precisely what stops a future commit upstream from executing here.

Also: the plan's instruction to add `revision=` to *both* `from_pretrained` calls is wrong for one of them — `weights/icon_caption_florence` is a local directory, where the argument is a no-op.

## Test plan

- [x] `pytest` in `packages/vision-svc` — **47 passed** (was 33)
- [x] New coverage: 5 schema-cap tests, 4 image-decode tests, 5 auth tests
- [x] TDD throughout — each test observed failing before the fix (RED → GREEN)
- [x] Checksum guard executed against the real 40.6 MB weights: passes
- [x] `trust_remote_code` removal attempted against real weights, failure captured above
- [x] Sidecar syntax-checked; gitleaks clean on all four commits
- [ ] Sidecar not smoke-tested end to end — needs YOLO + Florence-2 loaded on CPU, which the plan marks manual and out of CI
- [ ] TypeScript suite not run — no TS changed in this track

## Follow-ups

- Vendor + audit the Florence-2 modeling file to finish `omn-2`.
- The 401 body is FastAPI's `{"detail": ...}`, not the `VisionError` envelope the 422 handler produces. Worth reconciling before anything external consumes these errors.
- Remaining: track 4 (supply chain & CI) and the Phase-4 gate checklist.
